### PR TITLE
proper redirects for heroku

### DIFF
--- a/Tests/PointFreeTests/SiteMiddlewareTests.swift
+++ b/Tests/PointFreeTests/SiteMiddlewareTests.swift
@@ -7,35 +7,41 @@ import XCTest
 @testable import PointFree
 @testable import HttpPipeline
 import HttpPipelineTestSupport
+import Optics
+
+private func secureRequest(_ urlString: String) -> URLRequest {
+  return URLRequest(url: URL(string: urlString)!)
+    |> \.allHTTPHeaderFields .~ ["X-Forwarded-Proto": "https"]
+}
 
 class SiteMiddlewareTests: TestCase {
   func testWithoutWWW() {
     assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "https://pointfree.co")!)) |> siteMiddleware
+      matching: connection(from: secureRequest("https://pointfree.co")) |> siteMiddleware
     )
 
     assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "https://pointfree.co/episodes")!)) |> siteMiddleware
+      matching: connection(from: secureRequest("https://pointfree.co/episodes")) |> siteMiddleware
     )
   }
 
   func testWithoutHeroku() {
     assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "https://pointfreeco.herokuapp.com")!)) |> siteMiddleware
+      matching: connection(from: secureRequest("https://pointfreeco.herokuapp.com")) |> siteMiddleware
     )
 
     assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "https://pointfreeco.herokuapp.com/episodes")!)) |> siteMiddleware
+      matching: connection(from: secureRequest("https://pointfreeco.herokuapp.com/episodes")) |> siteMiddleware
     )
   }
 
   func testWithWWW() {
     assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!)) |> siteMiddleware
+      matching: connection(from: secureRequest("https://www.pointfree.co")) |> siteMiddleware
     )
 
     assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "https://www.pointfree.co/episodes")!)) |> siteMiddleware
+      matching: connection(from: secureRequest("https://www.pointfree.co/episodes")) |> siteMiddleware
     )
   }
 

--- a/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithWWW.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithWWW.1.Conn.txt
@@ -7,7 +7,7 @@ Request:
 URL: https://www.pointfree.co
 Method: GET
 Headers: [
-  
+    X-Forwarded-Proto: https
 ]
 Body: (Data, 0 bytes)
 

--- a/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithWWW.2.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithWWW.2.Conn.txt
@@ -7,7 +7,7 @@ Request:
 URL: https://www.pointfree.co/episodes
 Method: GET
 Headers: [
-  
+    X-Forwarded-Proto: https
 ]
 Body: (Data, 0 bytes)
 

--- a/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutHeroku.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutHeroku.1.Conn.txt
@@ -7,7 +7,7 @@ Request:
 URL: https://pointfreeco.herokuapp.com
 Method: GET
 Headers: [
-  
+    X-Forwarded-Proto: https
 ]
 Body: (Data, 0 bytes)
 

--- a/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutHeroku.2.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutHeroku.2.Conn.txt
@@ -7,7 +7,7 @@ Request:
 URL: https://pointfreeco.herokuapp.com/episodes
 Method: GET
 Headers: [
-  
+    X-Forwarded-Proto: https
 ]
 Body: (Data, 0 bytes)
 

--- a/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutWWW.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutWWW.1.Conn.txt
@@ -7,7 +7,7 @@ Request:
 URL: https://pointfree.co
 Method: GET
 Headers: [
-  
+    X-Forwarded-Proto: https
 ]
 Body: (Data, 0 bytes)
 

--- a/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutWWW.2.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SiteMiddlewareTests/testWithoutWWW.2.Conn.txt
@@ -7,7 +7,7 @@ Request:
 URL: https://pointfree.co/episodes
 Method: GET
 Headers: [
-  
+    X-Forwarded-Proto: https
 ]
 Body: (Data, 0 bytes)
 


### PR DESCRIPTION
it seems that checking the url scheme for `https` cannot be trusted in heroku and instead we must check a header: https://jaketrent.com/post/https-redirect-node-heroku/