### PR TITLE
Fix memory leak when dealing with URLSession

### DIFF
--- a/Sources/PointFree/LaunchSignup/Airtable.swift
+++ b/Sources/PointFree/LaunchSignup/Airtable.swift
@@ -18,9 +18,12 @@ func createRow(email: String)
 
       return .init(
         run: .init { callback in
-          URLSession(configuration: .default)
+          // TODO: make an `IO` helper for `URLSession` that does clean up automatically
+          let session = URLSession(configuration: .default)
+          session
             .dataTask(with: request) { data, response, error in
               callback(error == nil ? .right(unit) : .left(unit))
+              session.finishTasksAndInvalidate()
             }
             .resume()
         }


### PR DESCRIPTION
it seems that when you don't use `URLSession.shared` (which isn't in linux foundation) you gotta clean up yer session afterwards else you leak memory :/

doing this manually now but we could have an `IO` helper to make this better too...