### PR TITLE
Move env vars to .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ fastlane/test_output
 .DS_Store
 Packages/*
 *.xcodeproj/*
+.env

--- a/Sources/PointFree/EnvVars.swift
+++ b/Sources/PointFree/EnvVars.swift
@@ -7,8 +7,7 @@ enum EnvVars {
       .appendingPathComponent(".env")
 
     let localEnvVars = (try? Data(contentsOf: envFilePath))
-      .flatMap { try? JSONSerialization.jsonObject(with: $0) }
-      .flatMap { $0 as? [String: String] }
+      .flatMap { try? JSONDecoder().decode([String: String].self, from: $0) }
 
     return localEnvVars ?? ProcessInfo.processInfo.environment
   }()

--- a/Sources/PointFree/EnvVars.swift
+++ b/Sources/PointFree/EnvVars.swift
@@ -1,16 +1,19 @@
 import Foundation
 
 enum EnvVars {
-  private static var env: [String: String] {
-    return ProcessInfo.processInfo.environment
-  }
+  private static let env: [String: String] = {
+    let envFilePath = URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()
+      .appendingPathComponent(".env")
+
+    let localEnvVars = (try? Data(contentsOf: envFilePath))
+      .flatMap { try? JSONSerialization.jsonObject(with: $0) }
+      .flatMap { $0 as? [String: String] }
+
+    return localEnvVars ?? ProcessInfo.processInfo.environment
+  }()
 
   static let appSecret = env["APP_SECRET"] ?? "deadbeefdeadbeefdeadbeefdeadbeef"
-
-  enum BasicAuth {
-    static let username = env["BASIC_AUTH_USERNAME"] ?? "hello"
-    static let password = env["BASIC_AUTH_PASSWORD"] ?? "world"
-  }
 
   enum Airtable {
     static let base1 = env["AIRTABLE_BASE_1"] ?? "deadbeef-base-1"
@@ -19,8 +22,18 @@ enum EnvVars {
     static let bearer = env["AIRTABLE_BEARER"] ?? "deadbeef-bearer"
   }
 
+  enum BasicAuth {
+    static let username = env["BASIC_AUTH_USERNAME"] ?? "hello"
+    static let password = env["BASIC_AUTH_PASSWORD"] ?? "world"
+  }
+
   enum GitHub {
-    static let clientId = env["GITHUB_CLIENT_ID"] ?? "bf71e3ff1937fcd066d8"
-    static let clientSecret = env["GITHUB_CLIENT_SECRET"] ?? "94fb563ec0c21222db5d0254f228120030bf5bab"
+    static let clientId = env["GITHUB_CLIENT_ID"] ?? "deadbeef-client-id"
+    static let clientSecret = env["GITHUB_CLIENT_SECRET"] ?? "deadbeef-client-secret"
+  }
+
+  enum Stripe {
+    static let publishableKey = env["STRIPE_PUBLISHABLE_KEY"] ?? "pk_test"
+    static let secretKey = env["STRIPE_SECRET_KEY"] ?? "sk_test"
   }
 }

--- a/Tests/PointFreeTests/__Snapshots__/AuthTests/testLogin.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/AuthTests/testLogin.1.Conn.txt
@@ -9,4 +9,4 @@
 
 ▿ Response
   Status 302 FOUND
-  Location: https://github.com/login/oauth/authorize?scope=user:email&client_id=bf71e3ff1937fcd066d8
+  Location: https://github.com/login/oauth/authorize?scope=user:email&client_id=deadbeef-client-id


### PR DESCRIPTION
This will first try to load env vars from `.env` locally, and if that fails fallback to `ProcessInfo.processInfo.environment`. It should allow us to control the environment locally while keeping our true secrets only on the server.