### PR TITLE
Fun test stub cleanup using function composition

### DIFF
--- a/Sources/PointFree/GitHubApi.swift
+++ b/Sources/PointFree/GitHubApi.swift
@@ -54,20 +54,6 @@ func fetchAuthToken(forCode code: String) -> EitherIO<Prelude.Unit, GitHubAccess
   )
 }
 
-func mockFetchAuthToken(
-  result: Either<Prelude.Unit, GitHubAccessToken>
-  )
-  -> (String)
-  -> EitherIO<Prelude.Unit, GitHubAccessToken> {
-    return { code in
-      return .init(
-        run: .init { callback in
-          callback(result)
-        }
-      )
-    }
-}
-
 /// Fetches a GitHub user from an access token.
 func fetchGitHubUser(accessToken: GitHubAccessToken) -> EitherIO<Prelude.Unit, GitHubUser> {
 
@@ -90,20 +76,6 @@ func fetchGitHubUser(accessToken: GitHubAccessToken) -> EitherIO<Prelude.Unit, G
         .resume()
     }
   )
-}
-
-func mockFetchGithubUser(
-  result: Either<Prelude.Unit, GitHubUser>
-  )
-  -> (GitHubAccessToken)
-  -> EitherIO<Prelude.Unit, GitHubUser> {
-    return { code in
-      return .init(
-        run: .init { callback in
-          callback(result)
-        }
-      )
-    }
 }
 
 private let session = URLSession(configuration: .default)

--- a/Sources/PointFree/LaunchSignup/Airtable.swift
+++ b/Sources/PointFree/LaunchSignup/Airtable.swift
@@ -30,15 +30,3 @@ func createRow(email: String)
       )
     }
 }
-
-func mockCreateRow(result: Either<Prelude.Unit, Prelude.Unit>) -> AirtableCreateRow {
-  return { email in
-    return { baseId in
-      return .init(
-        run: .init { callback in
-          callback(result)
-        }
-      )
-    }
-  }
-}

--- a/Tests/PointFreeTests/AuthTests.swift
+++ b/Tests/PointFreeTests/AuthTests.swift
@@ -1,3 +1,4 @@
+import Either
 import HttpPipeline
 import HttpPipelineTestSupport
 import Optics
@@ -20,7 +21,7 @@ class AuthTests: TestCase {
   }
 
   func testAuth_WithFetchAuthTokenFailure() {
-    AppEnvironment.with(fetchAuthToken: mockFetchAuthToken(result: .left(unit))) {
+    AppEnvironment.with(fetchAuthToken: unit |> throwE >>> const) {
       let request = URLRequest(url: URL(string: "http://localhost:8080/github-auth?code=deadbeef")!)
         |> \.allHTTPHeaderFields .~ [
           "Authorization": "Basic " + Data("hello:world".utf8).base64EncodedString()
@@ -34,7 +35,7 @@ class AuthTests: TestCase {
   }
 
   func testAuth_WithFetchUserFailure() {
-    AppEnvironment.with(fetchGitHubUser: mockFetchGithubUser(result: .left(unit))) {
+    AppEnvironment.with(fetchGitHubUser: unit |> throwE >>> const) {
       let request = URLRequest(url: URL(string: "http://localhost:8080/github-auth?code=deadbeef")!)
         |> \.allHTTPHeaderFields .~ [
           "Authorization": "Basic " + Data("hello:world".utf8).base64EncodedString()

--- a/Tests/PointFreeTests/TestCase.swift
+++ b/Tests/PointFreeTests/TestCase.swift
@@ -1,3 +1,4 @@
+import Either
 @testable import PointFree
 import Prelude
 import SnapshotTesting
@@ -10,10 +11,8 @@ class TestCase: XCTestCase {
     AppEnvironment.push(
       env: .init(
         airtableStuff: mockCreateRow(result: .right(unit)),
-        fetchAuthToken: mockFetchAuthToken(result: .right(.init(accessToken: "deadbeef"))),
-        fetchGitHubUser: mockFetchGithubUser(
-          result: .right(.init(email: "hello@pointfree.co", id: 1, name: "Blob"))
-        )
+        fetchAuthToken: const(pure(.init(accessToken: "deadbeef"))),
+        fetchGitHubUser: const(pure(.init(email: "hello@pointfree.co", id: 1, name: "Blob")))
       )
     )
   }

--- a/Tests/PointFreeTests/TestCase.swift
+++ b/Tests/PointFreeTests/TestCase.swift
@@ -10,7 +10,7 @@ class TestCase: XCTestCase {
 
     AppEnvironment.push(
       env: .init(
-        airtableStuff: mockCreateRow(result: .right(unit)),
+        airtableStuff: const(const(pure(unit))),
         fetchAuthToken: const(pure(.init(accessToken: "deadbeef"))),
         fetchGitHubUser: const(pure(.init(email: "hello@pointfree.co", id: 1, name: "Blob")))
       )


### PR DESCRIPTION
Not sure if you prefer the explicitness of the mock names. If so we could still simplify the implementations, _e.g._:

``` swift
func mockFetchAuthToken(
  result: Either<Prelude.Unit, GitHubAccessToken>
  )
  -> (String)
  -> EitherIO<Prelude.Unit, GitHubAccessToken> {
    return result |> pure >>> const
}
```

They'd both have the same implementation, though!