### PR TITLE
Move middleware to its own file

### DIFF
--- a/Sources/PointFree/Routes.swift
+++ b/Sources/PointFree/Routes.swift
@@ -13,6 +13,7 @@ public enum Route {
 public let router: Router<Route> = [
   Route.iso.githubCallback
     <¢> get %> lit("github-auth") %> queryParam("code", .string) <%> queryParam("redirect", opt(.string)) <% end,
+  
   Route.iso.home
     <¢> get %> queryParam("success", opt(.bool)) <% end,
 

--- a/Sources/PointFree/Routes.swift
+++ b/Sources/PointFree/Routes.swift
@@ -1,23 +1,5 @@
 import ApplicativeRouter
-import ApplicativeRouterHttpPipelineSupport
-import Foundation
-import Html
-import HttpPipeline
-import Optics
 import Prelude
-import Styleguide
-
-public let siteMiddleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
-  requireHerokuHttps(allowedInsecureHosts: allowedInsecureHosts)
-    <<< redirectUnrelatedHosts(allowedHosts: allowedHosts, canonicalHost: canonicalHost)
-    <<< route(router: router)
-    <<< basicAuth(
-      user: EnvVars.BasicAuth.username,
-      password: EnvVars.BasicAuth.password,
-      realm: "Point-Free",
-      protect: isProtected
-    )
-    <| render(conn:)
 
 public enum Route {
   case githubCallback(code: String, redirect: String?)
@@ -26,7 +8,29 @@ public enum Route {
   case login(redirect: String?)
   case logout
   case secretHome
+}
 
+public let router: Router<Route> = [
+  Route.iso.githubCallback
+    <¢> get %> lit("github-auth") %> queryParam("code", .string) <%> queryParam("redirect", opt(.string)) <% end,
+  Route.iso.home
+    <¢> get %> queryParam("success", opt(.bool)) <% end,
+
+  Route.iso.launchSignup
+    <¢> post %> formField("email") <% lit("launch-signup") <% end,
+
+  Route.iso.login
+    <¢> get %> lit("login") %> queryParam("redirect", opt(.string)) <% end,
+
+  Route.iso.logout
+    <¢> get %> lit("logout") <% end,
+
+  Route.iso.secretHome
+    <¢> get %> lit("home") <% end,
+  ]
+  .reduce(.empty, <|>)
+
+extension Route {
   public enum iso {
     static let githubCallback = parenthesize <| PartialIso(
       apply: Route.githubCallback,
@@ -78,77 +82,4 @@ public func path(to route: Route) -> String {
 
 public func url(to route: Route) -> String {
   return router.url(for: route, base: AppEnvironment.current.baseUrl)?.absoluteString ?? ""
-}
-
-private let router: Router<Route> = [
-  Route.iso.githubCallback
-    <¢> get %> lit("github-auth") %> queryParam("code", .string) <%> queryParam("redirect", opt(.string)) <% end,
-  Route.iso.home
-    <¢> get %> queryParam("success", opt(.bool)) <% end,
-
-  Route.iso.launchSignup
-    <¢> post %> formField("email") <% lit("launch-signup") <% end,
-
-  Route.iso.login
-    <¢> get %> lit("login") %> queryParam("redirect", opt(.string)) <% end,
-
-  Route.iso.logout
-    <¢> get %> lit("logout") <% end,
-
-  Route.iso.secretHome
-    <¢> get %> lit("home") <% end,
-  ]
-  .reduce(.empty, <|>)
-
-private func render(conn: Conn<StatusLineOpen, Route>) -> IO<Conn<ResponseEnded, Data?>> {
-
-  switch conn.data {
-  case let .githubCallback(code, redirect):
-    return conn.map(const((code, redirect)))
-      |> githubCallbackResponse
-
-  case let .home(signedUpSuccessfully):
-    return conn.map(const(signedUpSuccessfully))
-      |> homeResponse
-
-  case let .launchSignup(email):
-    return conn.map(const(email))
-      |> signupResponse
-
-  case let .login(redirect):
-    return conn.map(const(redirect))
-      |> loginResponse
-
-  case .logout:
-    return conn.map(const(unit))
-      |> logoutResponse
-
-  case .secretHome:
-    return conn.map(const(unit))
-      |> secretHomeResponse
-  }
-}
-
-private let canonicalHost = "www.pointfree.co"
-private let allowedHosts: [String] = [
-  canonicalHost,
-  EnvVars.baseUrl?.host ?? canonicalHost,
-  "127.0.0.1",
-  "0.0.0.0",
-  "localhost"
-]
-
-private let allowedInsecureHosts: [String] = [
-  "127.0.0.1",
-  "0.0.0.0",
-  "localhost"
-]
-
-private func isProtected(route: Route) -> Bool {
-  switch route {
-  case .githubCallback, .login, .logout, .secretHome:
-    return true
-  case .home, .launchSignup:
-    return false
-  }
 }

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -1,0 +1,69 @@
+import ApplicativeRouterHttpPipelineSupport
+import Foundation
+import HttpPipeline
+import Prelude
+
+public let siteMiddleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+  requireHerokuHttps(allowedInsecureHosts: allowedInsecureHosts)
+    <<< redirectUnrelatedHosts(allowedHosts: allowedHosts, canonicalHost: canonicalHost)
+    <<< route(router: router)
+    <<< basicAuth(
+      user: EnvVars.BasicAuth.username,
+      password: EnvVars.BasicAuth.password,
+      realm: "Point-Free",
+      protect: isProtected
+    )
+    <| render(conn:)
+
+private func render(conn: Conn<StatusLineOpen, Route>) -> IO<Conn<ResponseEnded, Data?>> {
+
+  switch conn.data {
+  case let .githubCallback(code, redirect):
+    return conn.map(const((code, redirect)))
+      |> githubCallbackResponse
+
+  case let .home(signedUpSuccessfully):
+    return conn.map(const(signedUpSuccessfully))
+      |> homeResponse
+
+  case let .launchSignup(email):
+    return conn.map(const(email))
+      |> signupResponse
+
+  case let .login(redirect):
+    return conn.map(const(redirect))
+      |> loginResponse
+
+  case .logout:
+    return conn.map(const(unit))
+      |> logoutResponse
+
+  case .secretHome:
+    return conn.map(const(unit))
+      |> secretHomeResponse
+  }
+}
+
+private let canonicalHost = "www.pointfree.co"
+private let allowedHosts: [String] = [
+  canonicalHost,
+  EnvVars.baseUrl?.host ?? canonicalHost,
+  "127.0.0.1",
+  "0.0.0.0",
+  "localhost"
+]
+
+private let allowedInsecureHosts: [String] = [
+  "127.0.0.1",
+  "0.0.0.0",
+  "localhost"
+]
+
+private func isProtected(route: Route) -> Bool {
+  switch route {
+  case .githubCallback, .login, .logout, .secretHome:
+    return true
+  case .home, .launchSignup:
+    return false
+  }
+}


### PR DESCRIPTION
I've done this a few times in experimental branches, so just doing it once and for all. 

I just wanted the routes to be in its own file, and the site's middleware to be in another. makes it easier to see how to add new routes.