### PR TITLE
Error Handling Spike

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
         "package": "Web",
         "repositoryURL": "https://github.com/pointfreeco/swift-web.git",
         "state": {
-          "branch": "38e5c57",
-          "revision": "38e5c57edb7069fff62f5c005ce7b32f86b728c5",
+          "branch": "26f748c",
+          "revision": "26f748c81485ebca3d8e1c7dc87c539d91151556",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .library(name: "PointFree", targets: ["PointFree"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-web.git", .revision("38e5c57")),
+    .package(url: "https://github.com/pointfreeco/swift-web.git", .revision("26f748c")),
     .package(url: "https://github.com/pointfreeco/swift-prelude.git", .revision("9161df1")),
   ],
   targets: [

--- a/Tests/PointFreeTests/AuthTests.swift
+++ b/Tests/PointFreeTests/AuthTests.swift
@@ -7,7 +7,9 @@ import Prelude
 import SnapshotTesting
 import XCTest
 
-class AuthTests: TestCase {
+struct ServerError: Error {}
+
+final class AuthTests: TestCase {
   func testAuth() {
     let request = URLRequest(url: URL(string: "http://localhost:8080/github-auth?code=deadbeef")!)
       |> \.allHTTPHeaderFields .~ [
@@ -21,7 +23,7 @@ class AuthTests: TestCase {
   }
 
   func testAuth_WithFetchAuthTokenFailure() {
-    AppEnvironment.with(fetchAuthToken: unit |> throwE >>> const) {
+    AppEnvironment.with(fetchAuthToken: ServerError() |> throwE >>> const) {
       let request = URLRequest(url: URL(string: "http://localhost:8080/github-auth?code=deadbeef")!)
         |> \.allHTTPHeaderFields .~ [
           "Authorization": "Basic " + Data("hello:world".utf8).base64EncodedString()
@@ -35,7 +37,7 @@ class AuthTests: TestCase {
   }
 
   func testAuth_WithFetchUserFailure() {
-    AppEnvironment.with(fetchGitHubUser: unit |> throwE >>> const) {
+    AppEnvironment.with(fetchGitHubUser: ServerError() |> throwE >>> const) {
       let request = URLRequest(url: URL(string: "http://localhost:8080/github-auth?code=deadbeef")!)
         |> \.allHTTPHeaderFields .~ [
           "Authorization": "Basic " + Data("hello:world".utf8).base64EncodedString()

--- a/Tests/PointFreeTests/__Snapshots__/AuthTests/testAuth_WithFetchAuthTokenFailure.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/AuthTests/testAuth_WithFetchAuthTokenFailure.1.Conn.txt
@@ -8,5 +8,8 @@
   (Data, 0 bytes)
 
 ▿ Response
-  Status 302 FOUND
-  Location: /home
+  Status 500 INTERNAL SERVER ERROR
+  Content-Length: 76
+  Content-Type: text/plain
+
+  The operation couldn’t be completed. (PointFreeTests.ServerError error 1.)

--- a/Tests/PointFreeTests/__Snapshots__/AuthTests/testAuth_WithFetchUserFailure.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/AuthTests/testAuth_WithFetchUserFailure.1.Conn.txt
@@ -8,5 +8,8 @@
   (Data, 0 bytes)
 
 ▿ Response
-  Status 302 FOUND
-  Location: /home
+  Status 500 INTERNAL SERVER ERROR
+  Content-Length: 76
+  Content-Type: text/plain
+
+  The operation couldn’t be completed. (PointFreeTests.ServerError error 1.)


### PR DESCRIPTION
This shouldn't get merged in before we figure some things out, but wanted to get the discussion going about one way of handling errors.

This PR allows endpoints to lift their response data into `Either` to return potential errors. It's a little messy/noisy, though, and I'd like to figure out a better way of composing and working with these nested types.