### PR TITLE
Bootstrap function for starting up the site.

### DIFF
--- a/Sources/PointFree/Bootstrap.swift
+++ b/Sources/PointFree/Bootstrap.swift
@@ -5,7 +5,6 @@ public func bootstrap() -> EitherIO<Error, Prelude.Unit> {
 
   return print(message: "Bootstrapping PointFree...")
     .flatMap(const(connectToPostgres))
-    .flatMap(const(syncronizeMailgunNewsletterRoutes))
     .flatMap(const(print(message: "PointFree Bootstrapped!")))
 }
 

--- a/Sources/PointFree/Bootstrap.swift
+++ b/Sources/PointFree/Bootstrap.swift
@@ -20,4 +20,3 @@ private let connectToPostgres =
     .flatMap { _ in AppEnvironment.current.database.migrate() }
     .flatMap(const(print(message: "Connected to PostgreSQL!")))
     .retry(maxRetries: 999_999, backoff: const(.seconds(1)))
-

--- a/Sources/PointFree/Bootstrap.swift
+++ b/Sources/PointFree/Bootstrap.swift
@@ -1,0 +1,24 @@
+import Either
+import Prelude
+
+public func bootstrap() -> EitherIO<Error, Prelude.Unit> {
+
+  return print(message: "Bootstrapping PointFree...")
+    .flatMap(const(connectToPostgres))
+    .flatMap(const(syncronizeMailgunNewsletterRoutes))
+    .flatMap(const(print(message: "PointFree Bootstrapped!")))
+}
+
+private func print(message: String) -> EitherIO<Error, Prelude.Unit> {
+  return EitherIO<Error, Prelude.Unit>(run: IO {
+    print(message)
+    return .right(unit)
+  })
+}
+
+private let connectToPostgres =
+  print(message: "Connecting to PostgreSQL...")
+    .flatMap { _ in AppEnvironment.current.database.migrate() }
+    .flatMap(const(print(message: "Connected to PostgreSQL!")))
+    .retry(maxRetries: 999_999, backoff: const(.seconds(1)))
+

--- a/Sources/PointFree/Emails/Mailgun.swift
+++ b/Sources/PointFree/Emails/Mailgun.swift
@@ -38,6 +38,7 @@ public struct Email {
   var trackingClicks: TrackingClicks? = nil
   var trackingOpens: TrackingOpens? = nil
   var domain: String
+  var headers: [(String, String)] = []
 }
 
 public struct SendEmailResponse: Decodable {
@@ -58,6 +59,9 @@ func mailgunSend(email: Email) -> EitherIO<Prelude.Unit, SendEmailResponse> {
   params["tracking"] = email.tracking?.rawValue
   params["tracking-clicks"] = email.trackingClicks?.rawValue
   params["tracking-opens"] = email.trackingOpens?.rawValue
+  email.headers.forEach { key, value in
+    params["h:\(key)"] = value
+  }
 
   let request = URLRequest(
     url: URL(string: "https://api.mailgun.net/v3/\(AppEnvironment.current.envVars.mailgun.domain)/messages")!

--- a/Sources/PointFree/Emails/SendEmail.swift
+++ b/Sources/PointFree/Emails/SendEmail.swift
@@ -34,7 +34,8 @@ func sendEmail(
         tracking: nil,
         trackingClicks: nil,
         trackingOpens: nil,
-        domain: domain
+        domain: domain,
+        headers: []
       )
     )
 }

--- a/Sources/PointFree/TODO.swift
+++ b/Sources/PointFree/TODO.swift
@@ -392,13 +392,16 @@ extension EitherIO {
   }
 
   func retry(maxRetries: Int, backoff: @escaping (Int) -> DispatchTimeInterval) -> EitherIO {
-    return self.retry(maxRetries: maxRetries, attempts: 0, backoff: backoff)
+    return self.retry(maxRetries: maxRetries, attempts: 1, backoff: backoff)
   }
 
   private func retry(maxRetries: Int, attempts: Int, backoff: @escaping (Int) -> DispatchTimeInterval) -> EitherIO {
 
+    guard attempts < maxRetries else { return self }
+
     return self <|> .init(run:
       self
+        .retry(maxRetries: maxRetries, attempts: attempts + 1, backoff: backoff)
         .run
         .delay(backoff(attempts))
     )

--- a/Tests/PointFreeTests/EitherIOTests.swift
+++ b/Tests/PointFreeTests/EitherIOTests.swift
@@ -1,0 +1,33 @@
+import Either
+import XCTest
+@testable import PointFree
+import PointFreeTestSupport
+import Prelude
+
+class EitherIOTests: TestCase {
+  func testRetry_Fails() {
+    var count = 0
+    let thing = EitherIO<Prelude.Unit, Prelude.Unit>(run: IO {
+      count += 1
+      return count == 3 ? .right(unit) : .left(unit)
+    })
+      .retry(maxRetries: 2)
+
+    let result = thing.run.perform()
+
+    XCTAssertTrue(result.isLeft)
+  }
+
+  func testRetry_Succeeds() {
+    var count = 0
+    let thing = EitherIO<Prelude.Unit, Prelude.Unit>(run: IO {
+      count += 1
+      return count == 3 ? .right(unit) : .left(unit)
+    })
+      .retry(maxRetries: 3)
+
+    let result = thing.run.perform()
+
+    XCTAssertTrue(result.isRight)
+  }
+}


### PR DESCRIPTION
This started from me investigating what we'd need to do to support a `List-Unsubscribe` header in our emails. One component of it is for us to main a "mailgun route" for each of our newsletter types so that we can forward a reply to "unsubscribe-newsletter@pointfree.co" to our server, and then we handle the response.

Then that led me to wanting to synchronize those routes on mailgun via their API with the cases in our enum.

Then that led me to wanting to have a bootstrap function that runs when the server first boots up.

But we already have something like that in `pointfreeco-server` for starting up postgres.

So, I just made a general bootstrap function that can be called from the server. This is the place I would add that route synchronization stuff once I get to it.

Whatdya think?