### PR TITLE
No rule to make target `commoncrypto-mm'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-bootstrap: check-postgres commoncrypto-mm postgres-mm webkit-snapshot-mm init-db xcodeproj
+bootstrap: check-postgres common-crypto-mm postgres-mm webkit-snapshot-mm init-db xcodeproj
 
 imports = \
 	@testable import PointFreeTests; \


### PR DESCRIPTION
When running `make` I get the following error:
```
make: *** No rule to make target `commoncrypto-mm', needed by `bootstrap'.  Stop.
```

Turns out there was a typo in the `Makefile`.