### PR TITLE
Fix Docker command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y postgresql libpq-dev
 WORKDIR /app
 
 COPY Makefile ./
-RUN make install-cmark
+RUN make linux-install-cmark
 
 COPY Package.swift ./
 RUN swift package update
@@ -18,4 +18,4 @@ RUN swift package update
 COPY Sources ./Sources
 RUN swift build --configuration release
 
-CMD ./.build/release/pointfreeco
+CMD ./.build/release/Server


### PR DESCRIPTION
I just deployed and momentarily brought down the site... oops!

I found this in the logs:

```
2018-02-26T01:42:45.558032+00:00 app[web.2]: /bin/sh: 1: ./.build/release/pointfreeco: not found
```

and realized there was another server reference I didn't change in #164 