### PR TITLE
Add debug info to Stripe Hook signature failures

### DIFF
--- a/Sources/PointFree/StripeHook.swift
+++ b/Sources/PointFree/StripeHook.swift
@@ -30,7 +30,28 @@ private func validateStripeSignature<A>(
         let signatures = params["v1"],
         let payload = conn.request.httpBody.map({ String(decoding: $0, as: UTF8.self) }),
         signatures.contains(where: isSignatureValid(timestamp: timestamp, payload: payload))
-        else { return conn |> writeStatus(.badRequest) >-> end }
+        else {
+          var requestDump = ""
+          print("Current timestamp: \(AppEnvironment.current.date().timeIntervalSince1970)", to: &requestDump)
+          print(
+            "\(conn.request.httpMethod ?? "?METHOD?") \(conn.request.url?.absoluteString ?? "?URL?")",
+            to: &requestDump
+          )
+          print("\nHeaders:", to: &requestDump)
+          dump(conn.request.allHTTPHeaderFields, to: &requestDump)
+          print("\nBody:", to: &requestDump)
+          print(String(decoding: conn.request.httpBody ?? .init(), as: UTF8.self), to: &requestDump)
+
+          parallel(
+            sendEmail(
+              to: adminEmails.map(EmailAddress.init(unwrap:)),
+              subject: "[PointFree Error] Stripe Hook Failed!",
+              content: inj1(requestDump)
+              ).run
+            ).run { _ in }
+
+          return conn |> writeStatus(.badRequest) >-> end
+      }
 
       return conn |> middleware
     }


### PR DESCRIPTION
This should allow us to better troubleshoot any signature validation issues.