### PR TITLE
Environment.swift clean up

### DIFF
--- a/Sources/PointFree/About.swift
+++ b/Sources/PointFree/About.swift
@@ -279,6 +279,13 @@ functional convert and believer after years of objects.
   }
 }
 
+public struct Assets {
+  public var brandonImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/about-us/brando.jpg"
+  public var stephenImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/about-us/stephen.jpg"
+  public var emailHeaderImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/email-assets/pf-email-header.png"
+  public var pointersEmailHeaderImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/email-assets/pf-pointers-header.jpg"
+}
+
 private let hostImgClass = CssSelector.class("host-img")
 private let hostBioClass = CssSelector.class("host-bio")
 private let hostImgStyles =

--- a/Sources/PointFree/Blog/BlogPost.swift
+++ b/Sources/PointFree/Blog/BlogPost.swift
@@ -37,58 +37,58 @@ public struct BlogPost {
   }
 }
 
-let post0000_mock = BlogPost(
-  author: nil,
-  blurb: """
+extension BlogPost {
+  static let mock = BlogPost(
+    author: nil,
+    blurb: """
 This is the blurb to a mock blog post. This should just be short and to the point, using only plain
 text, no markdown.
 """,
-  contentBlocks: [
-    .init(
-      content: "",
-      timestamp: nil,
-      type: .video(poster: "", sources: [])
-    ),
-    .init(
-      content: """
-      This is the main content of the blog post. Each paragraph can use markdown, but titles code snippets
-      should be broken out into separate content blocks so that we can use the JS syntax highlighting
-      library. For example, here is some code:
-      """,
-      timestamp: nil,
-      type: .paragraph
-    ),
-    .init(
-      content: """
-      struct PredicateSet<A> {
-        let contains: (A) -> Bool
-      }
+    contentBlocks: [
+      .init(
+        content: "",
+        timestamp: nil,
+        type: .video(poster: "", sources: [])
+      ),
+      .init(
+        content: """
+This is the main content of the blog post. Each paragraph can use markdown, but titles code snippets
+should be broken out into separate content blocks so that we can use the JS syntax highlighting
+library. For example, here is some code:
+""",
+        timestamp: nil,
+        type: .paragraph
+      ),
+      .init(
+        content: """
+struct PredicateSet<A> {
+  let contains: (A) -> Bool
+}
 
-      func contramap<A, B>(_ f: @escaping (B) -> A) -> (PredicateSet<A>) -> PredicateSet<B> {
-        return { set in PredicateSet(contains: f >>> set.contains) }
-      }
-      """,
-      timestamp: nil,
-      type: .code(lang: .swift)
-    ),
-    .init(
-      content: "",
-      timestamp: nil,
-      type: .image(src: "")
-    ),
-    .init(
-      content: """
-      Cool stuff right? 
-      """,
-      timestamp: nil,
-      type: .paragraph
-    ),
-    ],
-  coverImage: "",
-  id: 0,
-  publishedAt: .init(timeIntervalSince1970: 1_523_872_623),
-  title: "Mock Blog Post"
-)
+func contramap<A, B>(_ f: @escaping (B) -> A) -> (PredicateSet<A>) -> PredicateSet<B> {
+  return { set in PredicateSet(contains: f >>> set.contains) }
+}
+""",
+        timestamp: nil,
+        type: .code(lang: .swift)
+      ),
+      .init(
+        content: "",
+        timestamp: nil,
+        type: .image(src: "")
+      ),
+      .init(
+        content: "Cool stuff right?",
+        timestamp: nil,
+        type: .paragraph
+      ),
+      ],
+    coverImage: "",
+    id: 0,
+    publishedAt: .init(timeIntervalSince1970: 1_523_872_623),
+    title: "Mock Blog Post"
+  )
+}
 
 extension PartialIso where A == Either<String, Int>, B == BlogPost {
   static var blogPostFromParam: PartialIso {

--- a/Sources/PointFree/Environment.swift
+++ b/Sources/PointFree/Environment.swift
@@ -3,59 +3,19 @@ import Foundation
 import Optics
 import Prelude
 
-public struct Assets {
-  public var brandonImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/about-us/brando.jpg"
-  public var stephenImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/about-us/stephen.jpg"
-  public var emailHeaderImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/email-assets/pf-email-header.png"
-  public var pointersEmailHeaderImgSrc = "https://d3rccdn33rt8ze.cloudfront.net/email-assets/pf-pointers-header.jpg"
-}
-
-public enum CookieTransform: String, Codable {
-  case plaintext
-  case encrypted
-}
-
 public var Current = Environment()
 
 public struct Environment {
-  public private(set) var assets: Assets
-  public private(set) var blogPosts: () -> [BlogPost]
-  public private(set) var cookieTransform: CookieTransform
-  public private(set) var database: Database
-  public private(set) var date: () -> Date
-  public private(set) var envVars: EnvVars
-  public private(set) var episodes: () -> [Episode]
-  public private(set) var features: [Feature]
-  public private(set) var gitHub: GitHub
-  public private(set) var logger: Logger
-  public private(set) var mailgun: Mailgun
-  public private(set) var stripe: Stripe
-
-  init(
-    assets: Assets = .init(),
-    blogPosts: @escaping () -> [BlogPost] = allBlogPosts,
-    cookieTransform: CookieTransform = .encrypted,
-    database: PointFree.Database = .live,
-    date: @escaping () -> Date = Date.init,
-    envVars: EnvVars = EnvVars(),
-    episodes: @escaping () -> [Episode] = { [typeSafeHtml, typeSafeHtml, typeSafeHtml] },
-    features: [Feature] = Feature.allFeatures,
-    gitHub: GitHub = .live,
-    logger: Logger = Logger(),
-    mailgun: Mailgun = .live,
-    stripe: Stripe = .live) {
-
-    self.assets = assets
-    self.blogPosts = blogPosts
-    self.cookieTransform = cookieTransform
-    self.database = database
-    self.date = date
-    self.envVars = envVars
-    self.episodes = episodes
-    self.features = features
-    self.gitHub = gitHub
-    self.logger = logger
-    self.mailgun = mailgun
-    self.stripe = stripe
-  }
+  public private(set) var assets: Assets = .init()
+  public private(set) var blogPosts: () -> [BlogPost] = allBlogPosts
+  public private(set) var cookieTransform: CookieTransform = .encrypted
+  public private(set) var database: Database = .live
+  public private(set) var date: () -> Date = Date.init
+  public private(set) var envVars: EnvVars = EnvVars()
+  public private(set) var episodes: () -> [Episode] = { [] }
+  public private(set) var features: [Feature] = .allFeatures
+  public private(set) var gitHub: GitHub = .live
+  public private(set) var logger: Logger = Logger()
+  public private(set) var mailgun: Mailgun = .live
+  public private(set) var stripe: Stripe = .live
 }

--- a/Sources/PointFree/FeatureFlags.swift
+++ b/Sources/PointFree/FeatureFlags.swift
@@ -5,8 +5,7 @@ public struct Feature: Equatable {
 }
 
 extension Array where Element == Feature {
-  static let allFeatures: Array = [
-  ]
+  static let allFeatures: Array = []
 
   func hasAccess(to feature: Feature, for user: Database.User?) -> Bool {
 

--- a/Sources/PointFree/FeatureFlags.swift
+++ b/Sources/PointFree/FeatureFlags.swift
@@ -2,12 +2,12 @@ public struct Feature: Equatable {
   fileprivate let isAdminEnabled: Bool
   fileprivate let isEnabled: Bool
   fileprivate let name: String
-
-  static let allFeatures: [Feature] = [
-  ]
 }
 
 extension Array where Element == Feature {
+  static let allFeatures: Array = [
+  ]
+
   func hasAccess(to feature: Feature, for user: Database.User?) -> Bool {
 
     return

--- a/Sources/PointFree/Session.swift
+++ b/Sources/PointFree/Session.swift
@@ -4,6 +4,11 @@ import Optics
 import Prelude
 import Tuple
 
+public enum CookieTransform: String, Codable {
+  case plaintext
+  case encrypted
+}
+
 public func writeSessionCookieMiddleware<A>(_ update: @escaping (Session) -> Session)
   -> (Conn<HeadersOpen, A>)
   -> IO<Conn<HeadersOpen, A>> {

--- a/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
+++ b/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
@@ -9,7 +9,7 @@ import Prelude
 extension Environment {
   public static let mock = Environment(
     assets: .mock,
-    blogPosts: { [post0000_mock] },
+    blogPosts: { [.mock] },
     cookieTransform: .plaintext,
     database: .mock,
     date: { .mock },

--- a/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
+++ b/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
@@ -7,7 +7,7 @@ import Optics
 import Prelude
 
 extension Environment {
-  public static let mock = Environment(
+  public static let mock = Environment.init(
     assets: .mock,
     blogPosts: { [.mock] },
     cookieTransform: .plaintext,
@@ -15,6 +15,7 @@ extension Environment {
     date: { .mock },
     envVars: .mock,
     episodes: { [.mock] },
+    features: .allFeatures,
     gitHub: .mock,
     logger: .mock,
     mailgun: .mock,

--- a/Tests/PointFreeTests/BlogTests.swift
+++ b/Tests/PointFreeTests/BlogTests.swift
@@ -48,7 +48,7 @@ class BlogTests: TestCase {
   }
 
   func testBlogShow() {
-    let req = request(to: .blog(.show(post0000_mock)), basicAuth: true)
+    let req = request(to: .blog(.show(.mock)), basicAuth: true)
     let result = connection(from: req)
       |> siteMiddleware
       |> Prelude.perform
@@ -68,7 +68,7 @@ class BlogTests: TestCase {
   }
 
   func testBlogShow_Unauthed() {
-    let req = request(to: .blog(.show(post0000_mock))) 
+    let req = request(to: .blog(.show(.mock))) 
     let result = connection(from: req)
       |> siteMiddleware
       |> Prelude.perform


### PR DESCRIPTION
Just moving ancillary stuff out of `Environment.swift` and leaning more on the initializer for `Environment` we get for free.