### PR TITLE
Use correct validators for example

### DIFF
--- a/Sources/PointFree/Blog/BlogPosts/BlogPost0014_AnnouncingValidated.swift
+++ b/Sources/PointFree/Blog/BlogPosts/BlogPost0014_AnnouncingValidated.swift
@@ -84,8 +84,8 @@ func validate(name: String) -> String throws {
 func validateUser(id: Int, email: String, name: String) throws -> User {
   return User(
     id: try validate(id: id),
-    email: try validate(id: email),
-    name: try validate(id: name)
+    email: try validate(email: email),
+    name: try validate(name: name)
   )
 }
 """,


### PR DESCRIPTION
This makes sure we use each specific validator for each example, rather than using the `id` validator each time.