### PR TITLE
Use assertSnapshots helper

### DIFF
--- a/Tests/PointFreeTests/AccountTests/AccountTests.swift
+++ b/Tests/PointFreeTests/AccountTests/AccountTests.swift
@@ -28,16 +28,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -53,16 +49,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2500)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2500)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2500)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2500))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -86,16 +78,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -119,16 +107,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -143,16 +127,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -167,16 +147,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -191,16 +167,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -219,16 +191,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -243,16 +211,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -267,16 +231,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -299,16 +259,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1500)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1500)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1500)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1500))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -332,16 +288,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1500)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1500)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1500)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1500))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -359,16 +311,12 @@ final class AccountTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/AccountTests/ChangeTests.swift
+++ b/Tests/PointFreeTests/AccountTests/ChangeTests.swift
@@ -25,16 +25,12 @@ final class ChangeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -63,16 +59,12 @@ final class ChangeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
+++ b/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
@@ -25,16 +25,12 @@ class PaymentInfoTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/BlogTests.swift
+++ b/Tests/PointFreeTests/BlogTests.swift
@@ -26,16 +26,12 @@ class BlogTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -54,16 +50,12 @@ class BlogTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 2400)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 2400)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 2400)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 2400))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -82,16 +74,12 @@ class BlogTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 2000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 2000)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 2000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/EpisodeTests.swift
+++ b/Tests/PointFreeTests/EpisodeTests.swift
@@ -28,16 +28,12 @@ class EpisodeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -52,16 +48,12 @@ class EpisodeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 2200)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 2200)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 2200)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 2200))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -81,16 +73,12 @@ class EpisodeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -110,16 +98,12 @@ class EpisodeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -166,16 +150,12 @@ class EpisodeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -205,16 +185,12 @@ class EpisodeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -244,16 +220,12 @@ class EpisodeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1100, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 500, height: 1800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
+          "mobile": .ioConnWebView(size: .init(width: 500, height: 1800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/HomeTests.swift
+++ b/Tests/PointFreeTests/HomeTests.swift
@@ -58,18 +58,13 @@ class HomeTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 2300)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 2300)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 2800))
+        ],
+        matching: conn |> siteMiddleware
       )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 2800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
-      )
-
     }
     #endif
   }

--- a/Tests/PointFreeTests/InvoicesTests.swift
+++ b/Tests/PointFreeTests/InvoicesTests.swift
@@ -25,16 +25,12 @@ final class InvoicesTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -47,16 +43,12 @@ final class InvoicesTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -75,16 +67,12 @@ final class InvoicesTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 800)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 800)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 800))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
+++ b/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
@@ -26,16 +26,12 @@ final class NotFoundMiddlewareTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -51,16 +47,12 @@ final class NotFoundMiddlewareTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/PricingTests.swift
+++ b/Tests/PointFreeTests/PricingTests.swift
@@ -58,16 +58,12 @@ class PricingTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1900)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1900)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1900)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1900))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif
@@ -85,16 +81,12 @@ class PricingTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1900)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1900)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1900)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1900))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif

--- a/Tests/PointFreeTests/PrivacyTests.swift
+++ b/Tests/PointFreeTests/PrivacyTests.swift
@@ -17,16 +17,12 @@ class PrivacyTests: TestCase {
 
     #if !os(Linux)
     if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 1080, height: 1000)),
-        matching: conn |> siteMiddleware,
-        named: "desktop"
-      )
-
-      assertSnapshot(
-        of: .ioConnWebView(size: .init(width: 400, height: 1000)),
-        matching: conn |> siteMiddleware,
-        named: "mobile"
+      assertSnapshots(
+        of: [
+          "desktop": .ioConnWebView(size: .init(width: 1080, height: 1000)),
+          "mobile": .ioConnWebView(size: .init(width: 400, height: 1000))
+        ],
+        matching: conn |> siteMiddleware
       )
     }
     #endif


### PR DESCRIPTION
Speeds up the test runner a bit since we're not creating a new IO for every web view snap.