### PR TITLE
Remove error email and expose all episodes in RSS.

### DIFF
--- a/Sources/PointFree/Account/PrivateRss.swift
+++ b/Sources/PointFree/Account/PrivateRss.swift
@@ -132,7 +132,10 @@ with anyone else.
 private func items(forUser user: Database.User) -> [RssItem] {
   return Current
     .episodes()
-    .filter { $0.sequence != 0 }
+    .filter {
+      $0.sequence != 0
+        && (Current.date().timeIntervalSince1970 - $0.publishedAt.timeIntervalSince1970) < 2592000.0
+    }
     .sorted(by: their(^\.sequence, >))
     .map { item(forUser: user, episode: $0) }
 }

--- a/Sources/PointFree/Account/PrivateRss.swift
+++ b/Sources/PointFree/Account/PrivateRss.swift
@@ -23,16 +23,6 @@ private func invalidatedFeedMiddleware<A>(errorMessage: String) -> (Conn<StatusL
   return { conn in
     conn.map(const(unit))
       |> writeStatus(.ok)
-      >=> { (conn: Conn<HeadersOpen, Prelude.Unit>) -> IO<Conn<HeadersOpen, Prelude.Unit>> in
-        
-        sendEmail(
-          to: adminEmails,
-          subject: "[Private Rss Feed Error] \(errorMessage)",
-          content: inj1(errorMessage)
-          ).run.parallel.run { _ in }
-
-        return pure(conn)
-      }
       >=> respond(invalidatedFeedView, contentType: .text(.init(rawValue: "xml"), charset: .utf8))
       >=> clearHeadBody
   }
@@ -140,14 +130,10 @@ with anyone else.
 }
 
 private func items(forUser user: Database.User) -> [RssItem] {
-  return [
-    Current
-      .episodes()
-      .filter { $0.sequence != 0 }
-      .sorted(by: their(^\.sequence, >))
-      .first
-    ]
-    .compactMap(id)
+  return Current
+    .episodes()
+    .filter { $0.sequence != 0 }
+    .sorted(by: their(^\.sequence, >))
     .map { item(forUser: user, episode: $0) }
 }
 

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class PrivateRssTests: TestCase {
   override func setUp() {
     super.setUp()
-//    record = true
+    record = true
   }
 
   func testFeed_Authenticated_Subscriber() {

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class PrivateRssTests: TestCase {
   override func setUp() {
     super.setUp()
-    record = true
+//    record = true
   }
 
   func testFeed_Authenticated_Subscriber() {
@@ -22,6 +22,16 @@ class PrivateRssTests: TestCase {
       &Current,
       \.database .~ .mock,
       \.database.fetchUserById .~ const(pure(.some(user)))
+    )
+
+    update(
+      &Current,
+      \.episodes .~ unzurry([
+        .subscriberOnly
+          |> \.publishedAt .~ Current.date(),
+        .free
+          |> \.publishedAt .~ Current.date().addingTimeInterval(-2678400)
+        ])
     )
 
     let conn = connection(

--- a/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account/rss/f9c46e50cb32c3f12369e92c8bb9d9db09edf2cce5
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 3059
+Content-Length: 5207
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -99,6 +99,74 @@ with anyone else.
         Training
       </itunes:category>
     </itunes:category>
+    <item>
+      <title>
+        Proof in Functions
+      </title>
+      <pubDate>
+        Wed, 31 Jan 2018 00:00:00 +0000
+      </pubDate>
+      <link>
+        http://localhost:8080/episodes/ep2-proof-in-functions
+      </link>
+      <guid>
+        http://localhost:8080/episodes/ep2-proof-in-functions
+      </guid>
+      <description>
+        This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
+text, no markdown allowed. Here is some more text just to have some filler.
+      </description>
+      <dc:creator>
+        Brandon Williams
+      </dc:creator>
+      <dc:creator>
+        Stephen Celis
+      </dc:creator>
+      <itunes:author>
+        Brandon Williams & Stephen Celis
+      </itunes:author>
+      <itunes:subtitle>
+        This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
+text, no markdown allowed. Here is some more text just to have some filler.
+      </itunes:subtitle>
+      <itunes:summary>
+        This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
+text, no markdown allowed. Here is some more text just to have some filler.
+      </itunes:summary>
+      <itunes:explicit>
+        no
+      </itunes:explicit>
+      <itunes:duration>
+        00:23:00
+      </itunes:duration>
+      <itunes:image>
+        https://s3.amazonaws.com/itunes.jpg
+      </itunes:image>
+      <itunes:season>
+        1
+      </itunes:season>
+      <itunes:episode>
+        2
+      </itunes:episode>
+      <itunes:title>
+        Proof in Functions
+      </itunes:title>
+      <itunes:episodeType>
+        full
+      </itunes:episodeType>
+      <enclosure url="https://s3.amazonaws.com/pointfreeco/video.mp4"
+                 length="500000000"
+                 type="video/mp4">
+      </enclosure>
+      <media:content url="https://s3.amazonaws.com/pointfreeco/video.mp4"
+                     length="500000000"
+                     type="video/mp4"
+                     medium="video">
+        <media:title>
+          Proof in Functions
+        </media:title>
+      </media:content>
+    </item>
   </channel>
 </rss>
 

--- a/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account/rss/f9c46e50cb32c3f12369e92c8bb9d9db09edf2cce5
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 5207
+Content-Length: 7470
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -164,6 +164,71 @@ text, no markdown allowed. Here is some more text just to have some filler.
                      medium="video">
         <media:title>
           Proof in Functions
+        </media:title>
+      </media:content>
+    </item>
+    <item>
+      <title>
+        Type-Safe HTML in Swift
+      </title>
+      <pubDate>
+        Tue, 20 Jun 2017 12:00:00 +0000
+      </pubDate>
+      <link>
+        http://localhost:8080/episodes/ep1-type-safe-html-in-swift
+      </link>
+      <guid>
+        http://localhost:8080/episodes/ep1-type-safe-html-in-swift
+      </guid>
+      <description>
+        As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.
+      </description>
+      <dc:creator>
+        Brandon Williams
+      </dc:creator>
+      <dc:creator>
+        Stephen Celis
+      </dc:creator>
+      <itunes:author>
+        Brandon Williams & Stephen Celis
+      </itunes:author>
+      <itunes:subtitle>
+        As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.
+      </itunes:subtitle>
+      <itunes:summary>
+        As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.
+      </itunes:summary>
+      <itunes:explicit>
+        no
+      </itunes:explicit>
+      <itunes:duration>
+        00:23:00
+      </itunes:duration>
+      <itunes:image>
+        https://s3.amazonaws.com/itunes.jpg
+      </itunes:image>
+      <itunes:season>
+        1
+      </itunes:season>
+      <itunes:episode>
+        1
+      </itunes:episode>
+      <itunes:title>
+        Type-Safe HTML in Swift
+      </itunes:title>
+      <itunes:episodeType>
+        full
+      </itunes:episodeType>
+      <enclosure url="https://s3.amazonaws.com/pointfreeco/video.mp4"
+                 length="500000000"
+                 type="video/mp4">
+      </enclosure>
+      <media:content url="https://s3.amazonaws.com/pointfreeco/video.mp4"
+                     length="500000000"
+                     type="video/mp4"
+                     medium="video">
+        <media:title>
+          Type-Safe HTML in Swift
         </media:title>
       </media:content>
     </item>

--- a/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account/rss/f9c46e50cb32c3f12369e92c8bb9d9db09edf2cce5
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 7470
+Content-Length: 3059
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -99,139 +99,6 @@ with anyone else.
         Training
       </itunes:category>
     </itunes:category>
-    <item>
-      <title>
-        Proof in Functions
-      </title>
-      <pubDate>
-        Tue, 20 Dec 2016 00:00:00 +0000
-      </pubDate>
-      <link>
-        http://localhost:8080/episodes/ep2-proof-in-functions
-      </link>
-      <guid>
-        http://localhost:8080/episodes/ep2-proof-in-functions
-      </guid>
-      <description>
-        This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
-text, no markdown allowed. Here is some more text just to have some filler.
-      </description>
-      <dc:creator>
-        Brandon Williams
-      </dc:creator>
-      <dc:creator>
-        Stephen Celis
-      </dc:creator>
-      <itunes:author>
-        Brandon Williams & Stephen Celis
-      </itunes:author>
-      <itunes:subtitle>
-        This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
-text, no markdown allowed. Here is some more text just to have some filler.
-      </itunes:subtitle>
-      <itunes:summary>
-        This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
-text, no markdown allowed. Here is some more text just to have some filler.
-      </itunes:summary>
-      <itunes:explicit>
-        no
-      </itunes:explicit>
-      <itunes:duration>
-        00:23:00
-      </itunes:duration>
-      <itunes:image>
-        https://s3.amazonaws.com/itunes.jpg
-      </itunes:image>
-      <itunes:season>
-        1
-      </itunes:season>
-      <itunes:episode>
-        2
-      </itunes:episode>
-      <itunes:title>
-        Proof in Functions
-      </itunes:title>
-      <itunes:episodeType>
-        full
-      </itunes:episodeType>
-      <enclosure url="https://s3.amazonaws.com/pointfreeco/video.mp4"
-                 length="500000000"
-                 type="video/mp4">
-      </enclosure>
-      <media:content url="https://s3.amazonaws.com/pointfreeco/video.mp4"
-                     length="500000000"
-                     type="video/mp4"
-                     medium="video">
-        <media:title>
-          Proof in Functions
-        </media:title>
-      </media:content>
-    </item>
-    <item>
-      <title>
-        Type-Safe HTML in Swift
-      </title>
-      <pubDate>
-        Tue, 20 Jun 2017 12:00:00 +0000
-      </pubDate>
-      <link>
-        http://localhost:8080/episodes/ep1-type-safe-html-in-swift
-      </link>
-      <guid>
-        http://localhost:8080/episodes/ep1-type-safe-html-in-swift
-      </guid>
-      <description>
-        As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.
-      </description>
-      <dc:creator>
-        Brandon Williams
-      </dc:creator>
-      <dc:creator>
-        Stephen Celis
-      </dc:creator>
-      <itunes:author>
-        Brandon Williams & Stephen Celis
-      </itunes:author>
-      <itunes:subtitle>
-        As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.
-      </itunes:subtitle>
-      <itunes:summary>
-        As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.
-      </itunes:summary>
-      <itunes:explicit>
-        no
-      </itunes:explicit>
-      <itunes:duration>
-        00:23:00
-      </itunes:duration>
-      <itunes:image>
-        https://s3.amazonaws.com/itunes.jpg
-      </itunes:image>
-      <itunes:season>
-        1
-      </itunes:season>
-      <itunes:episode>
-        1
-      </itunes:episode>
-      <itunes:title>
-        Type-Safe HTML in Swift
-      </itunes:title>
-      <itunes:episodeType>
-        full
-      </itunes:episodeType>
-      <enclosure url="https://s3.amazonaws.com/pointfreeco/video.mp4"
-                 length="500000000"
-                 type="video/mp4">
-      </enclosure>
-      <media:content url="https://s3.amazonaws.com/pointfreeco/video.mp4"
-                     length="500000000"
-                     type="video/mp4"
-                     medium="video">
-        <media:title>
-          Type-Safe HTML in Swift
-        </media:title>
-      </media:content>
-    </item>
   </channel>
 </rss>
 


### PR DESCRIPTION
Removing that `Private Rss Feed Error` email cause I think we know what is going on there. Also I'm now exposing all episodes in the private RSS feed. Seems maybe not worth doing what we are doing to combat fraudulent activity. Thoughts?