### PR TITLE
Deploy to Swift 4.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:4.2
+FROM norionomura/swift:421
 
 # postgres
 RUN apt-get update

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM norionomura/swift:41
+FROM norionomura/swift:421
 
 # postgres
 RUN apt-get update


### PR DESCRIPTION
For posterity, there are some Linux Foundation bugs that were fixed in Swift 4.1, regressed in Swift 4.2, and then fixed in 4.2.1 :/

Today we took down subscriptions for a few minutes because we deployed to Swift 4.2.