### PR TITLE
Add "Structure and Interpretation of Swift Programs" reference

### DIFF
--- a/Sources/PointFree/PublicEpisodes/References.swift
+++ b/Sources/PointFree/PublicEpisodes/References.swift
@@ -216,7 +216,10 @@ and provides some nice intuitions when dealing with such a counterintuitive idea
   static let structureAndInterpretationOfSwiftPrograms = Episode.Reference(
     author: "Colin Barrett",
     blurb: """
-Colin Barrett discusses the problems of dependency injection, the upsides of singletons, and introduces the `Environment` construct.
+[Colin Barrett](https://twitter.com/cbarrett) discussed the problems of dependency injection, the upsides
+of singletons, and introduced the `Environment` construct at [Functional Swift 2015](http://2015.funswiftconf.com).
+This was the talk that first inspired us to test this construct at Kickstarter and refine it over the years and
+many other code bases.
 """,
     link: "https://www.youtube.com/watch?v=V-YvI83QdMs",
     publishedAt: Date(timeIntervalSince1970: 1450155600),

--- a/Sources/PointFree/PublicEpisodes/References.swift
+++ b/Sources/PointFree/PublicEpisodes/References.swift
@@ -213,6 +213,16 @@ and provides some nice intuitions when dealing with such a counterintuitive idea
     title: "Some news about contramap"
   )
 
+  static let structureAndInterpretationOfSwiftPrograms = Episode.Reference(
+    author: "Colin Barrett",
+    blurb: """
+Colin Barrett discusses the problems of dependency injection, the upsides of singletons, and introduces the `Environment` construct.
+""",
+    link: "https://www.youtube.com/watch?v=V-YvI83QdMs",
+    publishedAt: Date(timeIntervalSince1970: 1450155600),
+    title: "Structure and Interpretation of Swift Programs"
+  )
+
   static let swiftNonEmpty = Episode.Reference(
     author: "Brandon Williams & Stephen Celis",
     blurb: """


### PR DESCRIPTION
I was reminded that @cbarrett's talk was the inspiration for the first version we tried at Kickstarter! I'll add the links to the transcripts repo once merged.