### PR TITLE
Re-enable logging, and refactor a bit.

### DIFF
--- a/Sources/PointFree/Logger.swift
+++ b/Sources/PointFree/Logger.swift
@@ -1,43 +1,99 @@
+import Foundation
 #if os(Linux)
 import Glibc
 #else
 import Darwin.C
 #endif
 
-public struct Logger {
-  private(set) var level: Level = .debug
-  private(set) var logger: (String) -> () = { print($0) }
+public class StandardFileHandle: TextOutputStream {
+  fileprivate let handle: FileHandle
 
-  init(level: Level = .debug, logger: @escaping (String) -> () = { print($0) }) {
-    self.level = level
-    self.logger = logger
+  public static let error = StandardFileHandle(handle: .standardError)
+  public static let output = StandardFileHandle(handle: .standardOutput)
+  public static let null = StandardFileHandle(handle: .nullDevice)
+
+  public init(handle: FileHandle) {
+    self.handle = handle
   }
 
-  public func log<A>(_ level: Level, _ message: @autoclosure () -> A) {
+  public func write(_ string: String) {
+    self.handle.write(Data(string.utf8))
+  }
+}
+
+public class Logger {
+  private let level: Level
+  private var output: StandardFileHandle
+  private var error: StandardFileHandle
+
+  init(
+    level: Level = .debug,
+    output: StandardFileHandle = .output,
+    error: StandardFileHandle = .error) {
+
+    self.level = level
+    self.output = output
+    self.error = error
+  }
+
+  public func log<A>(
+    _ level: Level,
+    _ message: @autoclosure () -> A,
+    file: StaticString = #file,
+    line: UInt = #line) {
+
+    let file = String(String(describing: file).split(separator: "/").last!)
+
     if level.rawValue >= self.level.rawValue {
-      //      self.logger(String(describing: message()))
-      //      fflush(stdout)
+      switch self.level {
+      case .debug, .info, .warn:
+        print("[\(self.level)] \(file):\(line): \(message())", to: &self.output)
+        self.output.handle.synchronizeFile()
+      case .error, .fatal:
+        print("[\(self.level)] \(file):\(line): \(message())", to: &self.error)
+        self.error.handle.synchronizeFile()
+      }
     }
   }
 
-  public func debug<A>(_ message: @autoclosure () -> A) {
-    self.log(.debug, message)
+  public func debug<A>(
+    _ message: @autoclosure () -> A,
+    file: StaticString = #file,
+    line: UInt = #line) {
+
+    self.log(.debug, message, file: file, line: line)
   }
 
-  public func info<A>(_ message: @autoclosure () -> A) {
-    self.log(.info, message)
+  public func info<A>(
+    _ message: @autoclosure () -> A,
+    file: StaticString = #file,
+    line: UInt = #line) {
+
+    self.log(.info, message, file: file, line: line)
   }
 
-  public func warn<A>(_ message: @autoclosure () -> A) {
-    self.log(.warn, message)
+  public func warn<A>(
+    _ message: @autoclosure () -> A,
+    file: StaticString = #file,
+    line: UInt = #line) {
+
+    self.log(.warn, message, file: file, line: line)
   }
 
-  public func error<A>(_ message: @autoclosure () -> A) {
-    self.log(.error, message)
+  public func error<A>(
+    _ message: @autoclosure () -> A,
+    file: StaticString = #file,
+    line: UInt = #line) {
+
+    self.log(.error, message, file: file, line: line)
   }
 
-  public func fatal<A>(_ message: @autoclosure () -> A) {
-    self.log(.fatal, message)
+  public func fatal<A>(
+    _ message: @autoclosure () -> A,
+    file: StaticString = #file,
+    line: UInt = #line) {
+
+    self.log(.fatal, message, file: file, line: line)
   }
 
   public enum Level: Int {
@@ -46,5 +102,22 @@ public struct Logger {
     case warn
     case error
     case fatal
+  }
+}
+
+import Either
+
+public func logError<A>(
+  subject: String,
+  file: StaticString = #file,
+  line: UInt = #line
+  ) -> (Error) -> EitherIO<Error, A> {
+
+  return { error in
+    var errorDump = ""
+    dump(error, to: &errorDump)
+    Current.logger.log(.error, errorDump, file: file, line: line)
+
+    return throwE(error)
   }
 }

--- a/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
+++ b/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
@@ -59,7 +59,7 @@ extension Assets {
 }
 
 extension Logger {
-  public static let mock = Logger(level: .debug, logger: { _ in })
+  public static let mock = Logger.init(level: .debug, output: .null, error: .null)
 }
 
 extension EnvVars {


### PR DESCRIPTION
We've had logged turned off for a while now due to crashes with `print` on Linux (we assumed it had to do with threading, but even logging on a serial queue crashed). Looks like at some point that was maybe fixed, so I think we could re-enable. Also we are now set up with logentries which gives us 5gb of logs and 7 days of retention.

There's also a small refactoring here to use file handles. I wanna deploy this and make sure it's stable, and if it is I'd like to add a bunch of logging to various spots.