### PR TITLE
Work around for swift compiler bug.

### DIFF
--- a/Sources/PointFree/Account/PrivateRss.swift
+++ b/Sources/PointFree/Account/PrivateRss.swift
@@ -57,7 +57,7 @@ private func validateUserAndSalt<Z>(
     }
 }
 
-private func trackFeedRequest<I, A>(_ conn: Conn<I, (A, Database.User)>) -> IO<Conn<I, (A, Database.User)>> {
+private func trackFeedRequest<I>(_ conn: Conn<I, (Stripe.Subscription?, Database.User)>) -> IO<Conn<I, (Stripe.Subscription?, Database.User)>> {
 
   return Current.database.createFeedRequestEvent(
     .privateEpisodesFeed,


### PR DESCRIPTION
We were getting compiler crashes when deploying, and this fixes it somehow. I have a feeling it's only the generic in the `trackFeedRequest` middleware, but I'm going to go ahead and leave the other stuff too.