### PR TITLE
Less qualification of functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
           command: system_profiler SPSoftwareDataType
 
       - run:
+          name: Brew upgrade
+          command: brew upgrade || brew upgrade
+
+      - run:
           name: Install Postgres
           command: brew install postgresql
 

--- a/Sources/PointFree/About.swift
+++ b/Sources/PointFree/About.swift
@@ -29,7 +29,7 @@ let aboutResponse: Middleware<StatusLineOpen, ResponseEnded, Tuple3<Database.Use
 private let aboutView = View<Prelude.Unit> { _ in
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 7], [
-      div([Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+      div([`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
           aboutSectionView.view(unit)
             + openSourceSection.view(unit)
       )
@@ -37,11 +37,11 @@ private let aboutView = View<Prelude.Unit> { _ in
 
     gridColumn(
       sizes: [.mobile: 12, .desktop: 5],
-      [Styleguide.class([Class.pf.colors.bg.purple150])],
+      [`class`([Class.pf.colors.bg.purple150])],
       [
         div(
           [
-            Styleguide.class([
+            `class`([
               Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]]),
               Class.pf.colors.bg.purple150,
               Class.position.sticky(.desktop),
@@ -58,7 +58,7 @@ private let hostsView = View<Prelude.Unit> { _ in
   [
     h1(
       [
-        Styleguide.class([
+        `class`([
           Class.pf.type.responsiveTitle3,
           Class.pf.colors.fg.white,
           Class.padding([.mobile: [.bottom: 2]])
@@ -68,13 +68,13 @@ private let hostsView = View<Prelude.Unit> { _ in
         "Your hosts"
       ]
     ),
-    p([Styleguide.class([Class.pf.type.body.regular, Class.pf.colors.fg.white, Class.padding([.mobile: [.bottom: 3]])])], [
+    p([`class`([Class.pf.type.body.regular, Class.pf.colors.fg.white, Class.padding([.mobile: [.bottom: 3]])])], [
       "Brandon and Stephen are software engineers living in Brooklyn, New York. They previously helped ",
       "build and ",
-      a([Styleguide.class([Class.pf.colors.link.green, Class.type.underline]), href("https://kickstarter.engineering/open-sourcing-our-android-and-ios-apps-6891be909fcd")],
+      a([`class`([Class.pf.colors.link.green, Class.type.underline]), href("https://kickstarter.engineering/open-sourcing-our-android-and-ios-apps-6891be909fcd")],
         ["open source"]),
       " the ",
-      a([Styleguide.class([Class.pf.colors.link.green, Class.type.underline]), href("https://www.kickstarter.com")], ["Kickstarter"]),
+      a([`class`([Class.pf.colors.link.green, Class.type.underline]), href("https://www.kickstarter.com")], ["Kickstarter"]),
       " mobile apps."
       ])
     ]
@@ -84,19 +84,19 @@ private let hostsView = View<Prelude.Unit> { _ in
 
 private let hostView = View<Host> { host in
   div(
-    [Styleguide.class([Class.padding([.mobile: [.bottom: 3]])])],
+    [`class`([Class.padding([.mobile: [.bottom: 3]])])],
     [
       img(
-        [src(host.image), alt("Photo of \(host.name)"), Styleguide.class([hostImgClass])]
+        [src(host.image), alt("Photo of \(host.name)"), `class`([hostImgClass])]
       ),
 
       div(
-        [Styleguide.class([hostBioClass])],
+        [`class`([hostBioClass])],
         [
           a(
             [
               href(host.website),
-              Styleguide.class([
+              `class`([
                 Class.pf.colors.link.white,
                 Class.h5,
                 Class.type.bold
@@ -107,12 +107,12 @@ private let hostView = View<Host> { host in
             ]
           ),
 
-          p([Styleguide.class([Class.pf.colors.fg.white, Class.pf.type.body.regular])], [.text(host.bio)]),
+          p([`class`([Class.pf.colors.fg.white, Class.pf.type.body.regular])], [.text(host.bio)]),
 
           a(
             [
               href(twitterUrl(to: host.twitterRoute)),
-              Styleguide.class([
+              `class`([
                 Class.pf.colors.link.white,
                 Class.padding([.mobile: [.top: 2]])
                 ])
@@ -123,7 +123,7 @@ private let hostView = View<Host> { host in
                 base64: rightArrowSvgBase64(fill: "#ffffff"),
                 type: .image(.svg),
                 alt: "",
-                [Styleguide.class([Class.align.middle, Class.margin([.mobile: [.left: 1]])]), width(16), height(16)]
+                [`class`([Class.align.middle, Class.margin([.mobile: [.left: 1]])]), width(16), height(16)]
               )
             ]
           )
@@ -135,7 +135,7 @@ private let hostView = View<Host> { host in
 
 private let aboutSectionView = View<Prelude.Unit> { _ in
   [
-    h1([Styleguide.class([Class.pf.type.responsiveTitle3])], ["About"]),
+    h1([`class`([Class.pf.type.responsiveTitle3])], ["About"]),
     markdownBlock("""
       Point-Free is a video series about functional programming and the Swift programming language. Each
       episode covers a topic that may seem complex and academic at first, but turns out to be quite simple.
@@ -147,10 +147,10 @@ private let aboutSectionView = View<Prelude.Unit> { _ in
     ),
 
     p([
-      ul([Styleguide.class([Class.type.list.styleNone, Class.padding([.mobile: [.left: 4, .topBottom: 2]])])], [
+      ul([`class`([Class.type.list.styleNone, Class.padding([.mobile: [.left: 4, .topBottom: 2]])])], [
         li([
-          h5([Styleguide.class([bulletPointTitleClass])], ["Pure functions and side effects"]),
-          p([Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
+          h5([`class`([bulletPointTitleClass])], ["Pure functions and side effects"]),
+          p([`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
             """
             Side effects are one of the greatest sources of complexity in an application, and every program
             has this in common. After giving a proper definition of side effects and pure functions, we will
@@ -160,8 +160,8 @@ private let aboutSectionView = View<Prelude.Unit> { _ in
           ]),
 
         li([
-          h5([Styleguide.class([bulletPointTitleClass])], ["Code reuse through function composition"]),
-          p([Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
+          h5([`class`([bulletPointTitleClass])], ["Code reuse through function composition"]),
+          p([`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
             """
             The most basic unit of code reusability comes in the form of simple function composition. We will
             show that by focusing on small atomic units that compose well, we can build large complex
@@ -170,8 +170,8 @@ private let aboutSectionView = View<Prelude.Unit> { _ in
           ]),
 
         li([
-          h5([Styleguide.class([bulletPointTitleClass])], ["Maximizing the use of the type system"]),
-          p([Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
+          h5([`class`([bulletPointTitleClass])], ["Maximizing the use of the type system"]),
+          p([`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
             """
             You’ve already seen how the type system helps prevent bugs by making sure you don’t accidentally
             add an integer to a string, or call a method on a “null” value, but it can do so much more. You
@@ -182,7 +182,7 @@ private let aboutSectionView = View<Prelude.Unit> { _ in
           ]),
 
         li([
-          h5([Styleguide.class([bulletPointTitleClass])], ["Turning programming problems into algebraic problems"]),
+          h5([`class`([bulletPointTitleClass])], ["Turning programming problems into algebraic problems"]),
           markdownBlock("""
             Algebraic problems are nice because they carry structure that can be manipulated in predictable
             and understandable ways. For example, if you have ever simplified a complicated boolean
@@ -201,16 +201,16 @@ private let aboutSectionView = View<Prelude.Unit> { _ in
 
 private let openSourceSection = View<Prelude.Unit> { _ in
   [
-    h1([Styleguide.class([Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 3]])])], ["Open source"]),
-    p([Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
+    h1([`class`([Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 3]])])], ["Open source"]),
+    p([`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
       "When we ",
-      a([href("https://kickstarter.engineering/open-sourcing-our-android-and-ios-apps-6891be909fcd"), Styleguide.class([Class.pf.colors.link.purple])], ["open-sourced"]),
+      a([href("https://kickstarter.engineering/open-sourcing-our-android-and-ios-apps-6891be909fcd"), `class`([Class.pf.colors.link.purple])], ["open-sourced"]),
       " the entire ",
-      a([href("http://github.com/kickstarter/ios-oss"), Styleguide.class([Class.pf.colors.link.purple])], ["iOS"]),
+      a([href("http://github.com/kickstarter/ios-oss"), `class`([Class.pf.colors.link.purple])], ["iOS"]),
       " and ",
-      a([href("http://github.com/kickstarter/android-oss"), Styleguide.class([Class.pf.colors.link.purple])], ["Android"]),
+      a([href("http://github.com/kickstarter/android-oss"), `class`([Class.pf.colors.link.purple])], ["Android"]),
       " codebases at ",
-      a([href("http://www.kickstarter.com"), Styleguide.class([Class.pf.colors.link.purple])], ["Kickstarter"]),
+      a([href("http://www.kickstarter.com"), `class`([Class.pf.colors.link.purple])], ["Kickstarter"]),
       """
       , we saw that it was one of the best resources to show people how to build a large application in
       the functional style. It transcended any talks about the theoretical benefits or proposed
@@ -219,23 +219,23 @@ private let openSourceSection = View<Prelude.Unit> { _ in
       """
       ]),
 
-    p([Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
+    p([`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
       """
       We wanted to be able to do that again, but this time we’d build an entire website in server-side Swift,
       all in the functional style! This meant we had to build nearly everything from scratch, from server
       middleware and routing to HTML views and CSS.
       """]),
 
-    p([Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
+    p([`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
       """
       We discovered quite a few fun things along the way, like using Swift Playgrounds to design pages in an
       iterative fashion, and came to the conclusion that server-side Swift will soon be a viable backend
       language rivaling almost every other language out there.
       """]),
 
-    p([Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
+    p([`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.bottom: 2]])])], [
       "You can view the entire source code to this site on our GitHub organization, ",
-      a([href(gitHubUrl(to: .organization)), Styleguide.class([Class.pf.colors.link.purple])], [.text(gitHubUrl(to: .organization))]),
+      a([href(gitHubUrl(to: .organization)), `class`([Class.pf.colors.link.purple])], [.text(gitHubUrl(to: .organization))]),
       "."
       ])
   ]

--- a/Sources/PointFree/Account/Account.swift
+++ b/Sources/PointFree/Account/Account.swift
@@ -104,7 +104,7 @@ private func fetchAccountData<I>(
 private let accountView = View<AccountData> { data in
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 8], [style(margin(leftRight: .auto))], [
-      div([Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+      div([`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
           titleRowView.view(unit)
             <> profileRowView.view(data)
             <> privateRssFeed.view(data)
@@ -122,11 +122,11 @@ private let creditsView = View<AccountData> { data -> [Node] in
   guard data.currentUser.episodeCreditCount > 0 || data.episodeCredits.count > 0 else { return [] }
 
   return [
-    gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 4]])])], [
+    gridRow([`class`([Class.padding([.mobile: [.bottom: 4]])])], [
       gridColumn(sizes: [.mobile: 12], [
         div(
           [
-            h2([Styleguide.class([Class.pf.type.responsiveTitle4])], ["Episode Credits"]),
+            h2([`class`([Class.pf.type.responsiveTitle4])], ["Episode Credits"]),
             p([
               "Episode credits allow you to see subscriber-only episodes before commiting to a full ",
               .text("subscription. You currently have \(pluralizedCredits(count: data.currentUser.episodeCreditCount)) "),
@@ -148,7 +148,7 @@ private let subscribeCallout = View<SubscriberState> { subscriberState -> [Node]
   return [
     p([
       "To get all past and future episodes, ",
-      a([Styleguide.class([Class.pf.colors.link.purple]), href(path(to: .pricing(nil, expand: nil)))], ["become"]),
+      a([`class`([Class.pf.colors.link.purple]), href(path(to: .pricing(nil, expand: nil)))], ["become"]),
       " a subscriber today!"
       ])
   ]
@@ -209,10 +209,10 @@ private func episode(atSequence sequence: Int) -> Episode? {
 }
 
 private let titleRowView = View<Prelude.Unit> { _ in
-  gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+  gridRow([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h1([Styleguide.class([Class.pf.type.responsiveTitle2])], ["Account"])
+        h1([`class`([Class.pf.type.responsiveTitle2])], ["Account"])
         ])
       ])
     ])
@@ -221,9 +221,9 @@ private let titleRowView = View<Prelude.Unit> { _ in
 private let profileRowView = View<AccountData> { data -> Node in
 
   let nameFields = [
-    label([Styleguide.class([labelClass])], ["Name"]),
+    label([`class`([labelClass])], ["Name"]),
     input([
-      Styleguide.class([blockInputClass]),
+      `class`([blockInputClass]),
       name(ProfileData.CodingKeys.name.stringValue),
       type(.text),
       value(data.currentUser.name ?? ""),
@@ -231,9 +231,9 @@ private let profileRowView = View<AccountData> { data -> Node in
   ]
 
   let emailFields = [
-    label([Styleguide.class([labelClass])], ["Email"]),
+    label([`class`([labelClass])], ["Email"]),
     input([
-      Styleguide.class([blockInputClass]),
+      `class`([blockInputClass]),
       name(ProfileData.CodingKeys.email.stringValue),
       type(.email),
       value(data.currentUser.email.rawValue)
@@ -241,11 +241,11 @@ private let profileRowView = View<AccountData> { data -> Node in
   ]
 
   let extraInvoiceInfoFields = !data.isSubscriptionOwner ? [] : [
-    label([Styleguide.class([labelClass])], ["Extra Invoice Info"]),
+    label([`class`([labelClass])], ["Extra Invoice Info"]),
     textarea(
       [
         placeholder("Company name, billing address, VAT number, ..."),
-        Styleguide.class([blockInputClass]),
+        `class`([blockInputClass]),
         name(ProfileData.CodingKeys.extraInvoiceInfo.stringValue),
       ],
       data.stripeSubscription?.customer.right?.extraInvoiceInfo ?? ""
@@ -255,15 +255,15 @@ private let profileRowView = View<AccountData> { data -> Node in
   let submit = [
     input([
       type(.submit),
-      Styleguide.class([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])]),
+      `class`([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])]),
       value("Update profile")
       ])
   ]
 
-  return gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 4]])])], [
+  return gridRow([`class`([Class.padding([.mobile: [.bottom: 4]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h2([Styleguide.class([Class.pf.type.responsiveTitle4])], ["Profile"]),
+        h2([`class`([Class.pf.type.responsiveTitle4])], ["Profile"]),
 
         form(
           [action(path(to: .account(.update(nil)))), method(.post)],
@@ -286,14 +286,14 @@ private let emailSettingCheckboxes = View<([Database.EmailSetting], SubscriberSt
   return [
     // TODO: hide `welcomeEmails` for subscribers?
     p(["Receive email for:"]),
-    p([Styleguide.class([Class.padding([.mobile: [.left: 1]])])], newsletters.map { newsletter in
-      label([Styleguide.class([Class.display.block])], [
+    p([`class`([Class.padding([.mobile: [.left: 1]])])], newsletters.map { newsletter in
+      label([`class`([Class.display.block])], [
         input(
           [
             type(.checkbox),
             name("emailSettings[\(newsletter.rawValue)]"),
             checked(currentEmailSettings.contains(where: ^\.newsletter == newsletter)),
-            Styleguide.class([Class.margin([.mobile: [.right: 1]])])
+            `class`([Class.margin([.mobile: [.right: 1]])])
           ]
         ),
         .text(newsletterDescription(newsletter))
@@ -424,10 +424,10 @@ private let subscriptionOwnerOverview = View<AccountData> { data -> [Node] in
   guard let subscription = data.stripeSubscription else { return [] }
 
   return [
-    gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 4]])])], [
+    gridRow([`class`([Class.padding([.mobile: [.bottom: 4]])])], [
       gridColumn(sizes: [.mobile: 12], [
         div([
-          h2([Styleguide.class([Class.pf.type.responsiveTitle4])], ["Subscription overview"]),
+          h2([`class`([Class.pf.type.responsiveTitle4])], ["Subscription overview"]),
 
           gridColumn(
             sizes: [.mobile: 12],
@@ -447,17 +447,17 @@ private let subscriptionTeammateOverview = View<AccountData> { data -> [Node] in
   guard let subscription = data.stripeSubscription else { return [] }
 
   return [
-    gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 4]])])], [
+    gridRow([`class`([Class.padding([.mobile: [.bottom: 4]])])], [
       gridColumn(sizes: [.mobile: 12], [
         div([
-          h2([Styleguide.class([Class.pf.type.responsiveTitle4])], ["Subscription overview"]),
+          h2([`class`([Class.pf.type.responsiveTitle4])], ["Subscription overview"]),
 
           p([
             "You are currently on a team subscription. Contact ",
             a(
               [
                 mailto(data.subscriptionOwner?.email.rawValue ?? ""),
-                Styleguide.class([Class.pf.colors.link.purple])
+                `class`([Class.pf.colors.link.purple])
               ],
               [
                 .text(data.subscriptionOwner?.name ?? "the owner")
@@ -469,7 +469,7 @@ private let subscriptionTeammateOverview = View<AccountData> { data -> [Node] in
           form([action(path(to: .team(.leave))), method(.post)], [
             input(
               [
-                Styleguide.class([Class.pf.components.button(color: .red, size: .small)]),
+                `class`([Class.pf.components.button(color: .red, size: .small)]),
                 type(.submit),
                 value("Leave this team")
               ]
@@ -529,12 +529,12 @@ private let subscriptionPlanRows = View<(Stripe.Subscription, Stripe.Invoice?)> 
     gridColumn(sizes: [.mobile: 9], [
       gridRow([
         gridColumn(sizes: [.mobile: 12, .desktop: 6], [
-          div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])], [
+          div([`class`([Class.padding([.mobile: [.leftRight: 1]])])], [
             p([.text(planName(for: subscription))])
             ])
           ]),
         gridColumn(sizes: [.mobile: 12, .desktop: 6], [
-          div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]]), Class.grid.end(.desktop)])], [
+          div([`class`([Class.padding([.mobile: [.leftRight: 1]]), Class.grid.end(.desktop)])], [
             p([mainAction(for: subscription)])
             ])
           ])
@@ -549,7 +549,7 @@ private let subscriptionPlanRows = View<(Stripe.Subscription, Stripe.Invoice?)> 
     gridColumn(sizes: [.mobile: 9], [
       gridRow([
         gridColumn(sizes: [.mobile: 12, .desktop: 6], [
-          div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])], [
+          div([`class`([Class.padding([.mobile: [.leftRight: 1]])])], [
             p([.text(status(for: subscription))])
             ])
           ])
@@ -564,7 +564,7 @@ private let subscriptionPlanRows = View<(Stripe.Subscription, Stripe.Invoice?)> 
         p([div(["Next billing"])])
         ]),
       gridColumn(sizes: [.mobile: 9], [
-        div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])], [
+        div([`class`([Class.padding([.mobile: [.leftRight: 1]])])], [
           p([.text(nextBilling(for: subscription, upcomingInvoice: upcomingInvoice))])
           ])
         ])
@@ -576,7 +576,7 @@ private let subscriptionPlanRows = View<(Stripe.Subscription, Stripe.Invoice?)> 
         p([div(["Discount"])])
         ]),
       gridColumn(sizes: [.mobile: 9], [
-        div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])], [
+        div([`class`([Class.padding([.mobile: [.leftRight: 1]])])], [
           p([.text(discountDescription(for: discount))])
           ])
         ])
@@ -584,7 +584,7 @@ private let subscriptionPlanRows = View<(Stripe.Subscription, Stripe.Invoice?)> 
   }
 
   return div(
-    [Styleguide.class([Class.padding([.mobile: [.top: 1, .bottom: 3]])])],
+    [`class`([Class.padding([.mobile: [.top: 1, .bottom: 3]])])],
     [planRow, statusRow] + [nextBillingRow, discountRow].compactMap(id)
   )
 }
@@ -599,7 +599,7 @@ private func mainAction(for subscription: Stripe.Subscription) -> Node {
       [action(path(to: .account(.subscription(.reactivate)))), method(.post)],
       [
         button(
-          [Styleguide.class([Class.pf.components.button(color: .purple, size: .small)])],
+          [`class`([Class.pf.components.button(color: .purple, size: .small)])],
           ["Reactivate"]
         )
       ]
@@ -607,7 +607,7 @@ private func mainAction(for subscription: Stripe.Subscription) -> Node {
   } else if subscription.status == .canceled {
     return a(
       [
-        Styleguide.class([Class.pf.components.button(color: .purple, size: .small)]),
+        `class`([Class.pf.components.button(color: .purple, size: .small)]),
         href(path(to: .pricing(nil, expand: nil)))
       ],
       ["Resubscribe"]
@@ -615,7 +615,7 @@ private func mainAction(for subscription: Stripe.Subscription) -> Node {
   } else {
     return a(
       [
-        Styleguide.class([Class.pf.components.button(color: .purple, size: .small)]),
+        `class`([Class.pf.components.button(color: .purple, size: .small)]),
         href(path(to: .account(.subscription(.change(.show)))))
       ],
       ["Modify subscription"]
@@ -627,14 +627,14 @@ private let subscriptionTeamRow = View<AccountData> { data -> [Node] in
   guard !data.teammates.isEmpty && data.isTeamSubscription else { return [] }
 
   return [
-    gridRow([Styleguide.class([subscriptionInfoRowClass])], [
+    gridRow([`class`([subscriptionInfoRowClass])], [
       gridColumn(sizes: [.mobile: 3], [
         div([
           p(["Team"])
           ])
         ]),
       gridColumn(sizes: [.mobile: 9], [
-        div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])],
+        div([`class`([Class.padding([.mobile: [.leftRight: 1]])])],
             [p(["Your current team:"])]
               <> data.teammates.flatMap { teammateRowView.view((data.currentUser, $0)) }
         )
@@ -651,9 +651,9 @@ private let teammateRowView = View<(Database.User, Database.User)> { currentUser
 
   return gridRow([
     gridColumn(sizes: [.mobile: 8], [p([.text(teammateLabel)])]),
-    gridColumn(sizes: [.mobile: 4], [Styleguide.class([Class.grid.end(.desktop)])], [
+    gridColumn(sizes: [.mobile: 4], [`class`([Class.grid.end(.desktop)])], [
       form([action(path(to: .team(.remove(teammate.id)))), method(.post)], [
-        p([input([type(.submit), Styleguide.class([Class.pf.components.button(color: .purple, size: .small)]), value("Remove")])])
+        p([input([type(.submit), `class`([Class.pf.components.button(color: .purple, size: .small)]), value("Remove")])])
         ]),
       ])
     ])
@@ -663,14 +663,14 @@ private let subscriptionInvitesRowView = View<[Database.TeamInvite]> { invites -
   guard !invites.isEmpty else { return [] }
 
   return [
-    gridRow([Styleguide.class([subscriptionInfoRowClass])], [
+    gridRow([`class`([subscriptionInfoRowClass])], [
       gridColumn(sizes: [.mobile: 3], [
         div([
           p(["Invites"])
           ])
         ]),
       gridColumn(sizes: [.mobile: 9], [
-        div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])],
+        div([`class`([Class.padding([.mobile: [.leftRight: 1]])])],
             [p(["These teammates have been invited, but have not yet accepted."])]
               <> invites.flatMap(inviteRowView.view))
         ])
@@ -683,13 +683,13 @@ private let inviteRowView = View<Database.TeamInvite> { invite in
     gridColumn(sizes: [.mobile: 12, .desktop: 6], [
       p([.text(invite.email.rawValue)])
       ]),
-    gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.grid.end(.desktop)])], [
-      form([action(path(to: .invite(.resend(invite.id)))), method(.post), Styleguide.class([Class.display.inlineBlock])], [
-        p([input([type(.submit), Styleguide.class([Class.pf.components.button(color: .purple, size: .small)]), value("Resend")])
+    gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.grid.end(.desktop)])], [
+      form([action(path(to: .invite(.resend(invite.id)))), method(.post), `class`([Class.display.inlineBlock])], [
+        p([input([type(.submit), `class`([Class.pf.components.button(color: .purple, size: .small)]), value("Resend")])
           ])]),
 
-      form([action(path(to: .invite(.revoke(invite.id)))), method(.post), Styleguide.class([Class.display.inlineBlock, Class.padding([.mobile: [.left: 1], .desktop: [.left: 2]])])], [
-        p([input([type(.submit), Styleguide.class([Class.pf.components.button(color: .red, size: .small, style: .underline)]), value("Revoke")])
+      form([action(path(to: .invite(.revoke(invite.id)))), method(.post), `class`([Class.display.inlineBlock, Class.padding([.mobile: [.left: 1], .desktop: [.left: 2]])])], [
+        p([input([type(.submit), `class`([Class.pf.components.button(color: .red, size: .small, style: .underline)]), value("Revoke")])
           ])]),
       ]),
     ])
@@ -703,29 +703,29 @@ private let subscriptionInviteMoreRowView = View<(Stripe.Subscription?, [Databas
   guard invitesRemaining > 0 else { return [] }
 
   return [
-    gridRow([Styleguide.class([subscriptionInfoRowClass])], [
+    gridRow([`class`([subscriptionInfoRowClass])], [
       gridColumn(sizes: [.mobile: 3], [
         div([
           p(["Invite more"])
           ])
         ]),
       gridColumn(sizes: [.mobile: 9], [
-        div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])], [
+        div([`class`([Class.padding([.mobile: [.leftRight: 1]])])], [
           p([.text("You have \(invitesRemaining) open spots on your team. Invite a team member below:")]),
 
           form([
             action(path(to: .invite(.send(nil)))), method(.post),
-            Styleguide.class([Class.flex.flex])
+            `class`([Class.flex.flex])
             ], [
               input([
-                Styleguide.class([smallInputClass, Class.align.middle, Class.size.width100pct]),
+                `class`([smallInputClass, Class.align.middle, Class.size.width100pct]),
                 name("email"),
                 placeholder("blob@example.com"),
                 type(.email),
                 ]),
               input([
                 type(.submit),
-                Styleguide.class([
+                `class`([
                   Class.pf.components.button(color: .purple, size: .small),
                   Class.align.middle,
                   Class.margin([.mobile: [.left: 1], .desktop: [.left: 2]])
@@ -742,7 +742,7 @@ private let subscriptionPaymentInfoView = View<Stripe.Subscription> { subscripti
   guard let card = subscription.customer.right?.sources.data.first else { return [] }
 
   return [
-    gridRow([Styleguide.class([subscriptionInfoRowClass])], [
+    gridRow([`class`([subscriptionInfoRowClass])], [
       gridColumn(sizes: [.mobile: 3], [
         div([
           p(["Payment"])
@@ -751,23 +751,23 @@ private let subscriptionPaymentInfoView = View<Stripe.Subscription> { subscripti
       gridColumn(sizes: [.desktop: 9], [
         gridRow([
           gridColumn(sizes: [.mobile: 12, .desktop: 6], [
-            div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]])])], [
+            div([`class`([Class.padding([.mobile: [.leftRight: 1]])])], [
               p([.text(card.brand.rawValue + " ending in " + String(card.last4))]),
               p([.text("Expires " + String(card.expMonth) + "/" + String(card.expYear))]),
               ])
             ]),
           gridColumn(sizes: [.mobile: 12, .desktop: 6], [
-            div([Styleguide.class([Class.padding([.mobile: [.leftRight: 1]]), Class.grid.end(.desktop)])], [
+            div([`class`([Class.padding([.mobile: [.leftRight: 1]]), Class.grid.end(.desktop)])], [
               p([
                 a([
-                  Styleguide.class([Class.pf.components.button(color: .purple, size: .small)]),
+                  `class`([Class.pf.components.button(color: .purple, size: .small)]),
                   href(path(to: .account(.paymentInfo(.show(expand: nil))))),
                   ],
                   ["Update payment method"])
                 ]),
               p([
                 a([
-                  Styleguide.class([Class.pf.components.button(color: .black, size: .small, style: .underline)]),
+                  `class`([Class.pf.components.button(color: .black, size: .small, style: .underline)]),
                   href(path(to: .account(.invoices(.index)))),
                   ],
                   ["Payment history"])
@@ -789,7 +789,7 @@ public func format(cents: Stripe.Cents) -> String {
 private let logoutView = View<Prelude.Unit> { _ in
   gridRow([
     gridColumn(sizes: [.mobile: 12], [
-      a([Styleguide.class([Class.pf.components.button(color: .black)]), href(path(to: .logout))], ["Logout"])
+      a([`class`([Class.pf.components.button(color: .black)]), href(path(to: .logout))], ["Logout"])
       ])
     ])
 }

--- a/Sources/PointFree/Account/Cancel.swift
+++ b/Sources/PointFree/Account/Cancel.swift
@@ -224,9 +224,9 @@ private let cancelEmailBodyView = View<(Database.User, Stripe.Subscription)> { u
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Subscription canceled"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Subscription canceled"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             "Your ",
             strong([.text(subscription.plan.name)]),
             " subscription has been canceled and will remain active through ",
@@ -267,9 +267,9 @@ private let reactivateEmailBodyView = View<(Database.User, Stripe.Subscription)>
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Subscription reactivated"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Subscription reactivated"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             "Thanks for sticking with us! Your ",
             strong([.text(subscription.plan.name)]),
             " subscription has been reactivated and will renew on ",

--- a/Sources/PointFree/Account/Change.swift
+++ b/Sources/PointFree/Account/Change.swift
@@ -181,7 +181,7 @@ let subscriptionChangeShowView = View<(Stripe.Subscription, Database.User, Int)>
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 8], [style(margin(leftRight: .auto))], [
       div(
-        [Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+        [`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
         titleRowView.view(subscription)
           <> formRowView.view((subscription, seatsTaken))
           <> cancelRowView.view(subscription)
@@ -191,10 +191,10 @@ let subscriptionChangeShowView = View<(Stripe.Subscription, Database.User, Int)>
 }
 
 private let titleRowView = View<Stripe.Subscription> { subscription in
-  gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+  gridRow([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h1([Styleguide.class([Class.pf.type.responsiveTitle2])], ["Modify subscription"]),
+        h1([`class`([Class.pf.type.responsiveTitle2])], ["Modify subscription"]),
         p([
           "You are currently enrolled in the ", strong([.text(subscription.plan.name)]), " plan. ",
           "Your subscription will ",
@@ -214,11 +214,11 @@ private let titleRowView = View<Stripe.Subscription> { subscription in
 private let formRowView = View<(Stripe.Subscription, Int)> { subscription, seatsTaken -> Node in
 
   return form(
-    [action(path(to: .account(.subscription(.change(.update(nil)))))), method(.post), Styleguide.class([Class.margin([.mobile: [.bottom: 3]])])],
+    [action(path(to: .account(.subscription(.change(.update(nil)))))), method(.post), `class`([Class.margin([.mobile: [.bottom: 3]])])],
     changeSeatsRowView.view((subscription, seatsTaken))
       <> changeBillingIntervalRowView.view(subscription)
       <> [
-        hr([Styleguide.class([Class.pf.components.divider])])
+        hr([`class`([Class.pf.components.divider])])
     ]
   )
 }
@@ -236,9 +236,9 @@ private let changeSeatsRowView = View<(Stripe.Subscription, Int)> { subscription
       strong([.text(String(subscription.quantity))]), " seats"]), " available."
   ]
 
-  return gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+  return gridRow([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
     gridColumn(sizes: [.mobile: 12], [
-      h3([Styleguide.class([Class.pf.type.responsiveTitle4])], [.text(subtitle)]),
+      h3([`class`([Class.pf.type.responsiveTitle4])], [.text(subtitle)]),
       p(description + [" ",
         """
         Additional costs will be billed immediately, prorated against the remaining time of
@@ -268,7 +268,7 @@ private let changeSeatsRowView = View<(Stripe.Subscription, Int)> { subscription
         ),
         step(1),
         value(clamp(1..<Pricing.validTeamQuantities.upperBound) <| subscription.quantity),
-        Styleguide.class([numberSpinner, Class.pf.colors.fg.black])
+        `class`([numberSpinner, Class.pf.colors.fg.black])
         ])
       ])
     ])
@@ -283,9 +283,9 @@ private let changeBillingIntervalRowView = View<Stripe.Subscription> { subscript
     ? "Change to yearly billing?"
     : "Change to monthly billing?"
 
-  return gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 4]])])], [
+  return gridRow([`class`([Class.padding([.mobile: [.bottom: 4]])])], [
     gridColumn(sizes: [.mobile: 12], [
-      h3([Styleguide.class([Class.pf.type.responsiveTitle4])], [.text(subtitle)]),
+      h3([`class`([Class.pf.type.responsiveTitle4])], [.text(subtitle)]),
       p([
         """
         Your regular billing rate will be reflected below. Upgrades and downgrades will take
@@ -313,13 +313,13 @@ private let changeBillingIntervalRowView = View<Stripe.Subscription> { subscript
       )
       + [
       button(
-        [Styleguide.class([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])])],
+        [`class`([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])])],
         [subscription.isRenewing ? "Update my subscription" : "Reactivate my subscription"]
       ),
       a(
         [
           href(path(to: .account(.index))),
-          Styleguide.class([Class.pf.components.button(color: .black, style: .underline)])
+          `class`([Class.pf.components.button(color: .black, style: .underline)])
         ],
         ["Never mind"]
       )
@@ -329,11 +329,11 @@ private let changeBillingIntervalRowView = View<Stripe.Subscription> { subscript
 }
 
 private let individualPricingColumnView = View<(Pricing.Billing, Pricing)> { billing, pricing -> Node in
-  return gridColumn(sizes: [.mobile: 16], [Styleguide.class([Class.pf.colors.bg.white])], [
-    label([`for`(billing.rawValue), Styleguide.class([Class.display.block, Class.margin([.mobile: [.topBottom: 3]])])], [
+  return gridColumn(sizes: [.mobile: 16], [`class`([Class.pf.colors.bg.white])], [
+    label([`for`(billing.rawValue), `class`([Class.display.block, Class.margin([.mobile: [.topBottom: 3]])])], [
       gridRow([style(flex(direction: .columnReverse))], [
         input([
-          Styleguide.class([Class.h3]),
+          `class`([Class.h3]),
           checked(isChecked(billing, pricing)),
           id(billing.rawValue),
           name("billing"),
@@ -341,11 +341,11 @@ private let individualPricingColumnView = View<(Pricing.Billing, Pricing)> { bil
           value(billing.rawValue),
           ]),
         gridColumn(sizes: [.mobile: 12], [], [
-          h2([Styleguide.class([Class.pf.type.responsiveTitle2, Class.type.light, Class.pf.colors.fg.gray650])], [
+          h2([`class`([Class.pf.type.responsiveTitle2, Class.type.light, Class.pf.colors.fg.gray650])], [
             "$",
             span(
               [
-                Styleguide.class([priceClass]),
+                `class`([priceClass]),
                 data("price-individual", String(defaultPricing(for: .individual, billing: billing))),
                 data("price-team", String(defaultPricing(for: .team, billing: billing)))
               ],
@@ -356,7 +356,7 @@ private let individualPricingColumnView = View<(Pricing.Billing, Pricing)> { bil
             ]),
           ]),
         gridColumn(sizes: [.mobile: 12], [], [
-          h6([Styleguide.class([Class.pf.type.responsiveTitle7, Class.pf.colors.fg.gray650, Class.display.inline])], [
+          h6([`class`([Class.pf.type.responsiveTitle7, Class.pf.colors.fg.gray650, Class.display.inline])], [
             .text(title(for: billing))
             ])
           ])
@@ -383,9 +383,9 @@ private let cancelRowView = View<Stripe.Subscription> { subscription -> [Node] i
   guard subscription.isRenewing else { return [] }
 
   return [
-    gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 4]])])], [
+    gridRow([`class`([Class.padding([.mobile: [.bottom: 4]])])], [
       gridColumn(sizes: [.mobile: 12], [
-        h3([Styleguide.class([Class.pf.type.responsiveTitle4])], ["Cancel your subscription?"]),
+        h3([`class`([Class.pf.type.responsiveTitle4])], ["Cancel your subscription?"]),
         p([
           "If you cancel your subscription, you’ll lose access to Point-Free on ",
           strong([.text(dateFormatter.string(from: subscription.currentPeriodEnd))]),
@@ -396,13 +396,13 @@ private let cancelRowView = View<Stripe.Subscription> { subscription -> [Node] i
           ]),
         form([action(path(to: .account(.subscription(.cancel)))), method(.post)], [
           button(
-            [Styleguide.class([Class.pf.components.button(color: .red), Class.margin([.mobile: [.top: 3]])])],
+            [`class`([Class.pf.components.button(color: .red), Class.margin([.mobile: [.top: 3]])])],
             ["Yes, cancel my subscription"]
           ),
           a(
             [
               href(path(to: .account(.index))),
-              Styleguide.class([Class.pf.components.button(color: .black, style: .underline)])
+              `class`([Class.pf.components.button(color: .black, style: .underline)])
             ],
             ["Never mind"]
           )

--- a/Sources/PointFree/Account/Invite.swift
+++ b/Sources/PointFree/Account/Invite.swift
@@ -147,7 +147,7 @@ let showInviteView = View<(Database.TeamInvite, Database.User, Database.User?)> 
 
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 8], [style(margin(leftRight: .auto))], [
-      div([Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+      div([`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
           currentUser
             .map { showInviteLoggedInView.view(($0, teamInvite, inviter)) }
             ?? showInviteLoggedOutView.view((teamInvite, inviter))
@@ -157,10 +157,10 @@ let showInviteView = View<(Database.TeamInvite, Database.User, Database.User?)> 
 }
 
 private let showInviteLoggedOutView = View<(Database.TeamInvite, Database.User)> { invite, inviter in
-  gridRow([Styleguide.class([Class.padding([.mobile: [.topBottom: 4]])])], [
+  gridRow([`class`([Class.padding([.mobile: [.topBottom: 4]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["You’ve been invited!"]),
+        h3([`class`([Class.pf.type.responsiveTitle3])], ["You’ve been invited!"]),
 
         p([
           "Your colleague ",
@@ -176,7 +176,7 @@ private let showInviteLoggedOutView = View<(Database.TeamInvite, Database.User)>
           "You must be logged in to accept this invitation. Would you like to log in with GitHub?"
           ]),
 
-        p([Styleguide.class([Class.padding([.mobile: [.top: 3]])])], [
+        p([`class`([Class.padding([.mobile: [.top: 3]])])], [
           gitHubLink(text: "Login with GitHub", type: .black, redirectRoute: .invite(.show(invite.id)))
           ])
         ])
@@ -185,10 +185,10 @@ private let showInviteLoggedOutView = View<(Database.TeamInvite, Database.User)>
 }
 
 private let showInviteLoggedInView = View<(Database.User, Database.TeamInvite, Database.User)> { currentUser, teamInvite, inviter in
-  gridRow([Styleguide.class([Class.padding([.mobile: [.topBottom: 4]])])], [
+  gridRow([`class`([Class.padding([.mobile: [.topBottom: 4]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["You’ve been invited!"]),
+        h3([`class`([Class.pf.type.responsiveTitle3])], ["You’ve been invited!"]),
 
         p([
           "Your colleague ",
@@ -204,7 +204,7 @@ private let showInviteLoggedInView = View<(Database.User, Database.TeamInvite, D
           input([
               type(.submit),
               value("Accept"),
-              Styleguide.class([Class.pf.components.button(color: .purple)])
+              `class`([Class.pf.components.button(color: .purple)])
             ])
           ])
         ])
@@ -216,8 +216,8 @@ private let inviteNotFoundView = View<Prelude.Unit> { _ in
 
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 8], [style(margin(leftRight: .auto))], [
-      div([Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])], [
-        h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Invite not found"]),
+      div([`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])], [
+        h3([`class`([Class.pf.type.responsiveTitle3])], ["Invite not found"]),
 
         p([
           """
@@ -226,11 +226,11 @@ private let inviteNotFoundView = View<Prelude.Unit> { _ in
           """
           ]),
 
-        p([Styleguide.class([Class.padding([.mobile: [.top: 3]])])], [
+        p([`class`([Class.padding([.mobile: [.top: 3]])])], [
           a(
             [
               href(path(to: .pricing(nil, expand: nil))),
-              Styleguide.class([Class.pf.components.button(color: .purple)])
+              `class`([Class.pf.components.button(color: .purple)])
             ],
             ["Subscribe"])
           ])

--- a/Sources/PointFree/Account/Invoices.swift
+++ b/Sources/PointFree/Account/Invoices.swift
@@ -109,7 +109,7 @@ let invoicesView = View<(Stripe.Subscription, Stripe.ListEnvelope<Stripe.Invoice
 
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 8], [style(margin(leftRight: .auto))], [
-      div([Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+      div([`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
           titleRowView.view(unit)
             <> invoicesRowView.view(invoicesEnvelope)
       )
@@ -118,10 +118,10 @@ let invoicesView = View<(Stripe.Subscription, Stripe.ListEnvelope<Stripe.Invoice
 }
 
 private let titleRowView = View<Prelude.Unit> { _ in
-  gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+  gridRow([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h1([Styleguide.class([Class.pf.type.responsiveTitle2])], ["Payment history"])
+        h1([`class`([Class.pf.type.responsiveTitle2])], ["Payment history"])
         ])
       ])
     ])
@@ -130,21 +130,21 @@ private let titleRowView = View<Prelude.Unit> { _ in
 private let invoicesRowView = View<Stripe.ListEnvelope<Stripe.Invoice>> { invoicesEnvelope in
   div(
     invoicesEnvelope.data.map { invoice in
-      gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
-        gridColumn(sizes: [.mobile: 4], [Styleguide.class([Class.type.fontFamily.monospace])], [
+      gridRow([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
+        gridColumn(sizes: [.mobile: 4], [`class`([Class.type.fontFamily.monospace])], [
           div([.text("#" + invoice.number.rawValue)])
           ]),
-        gridColumn(sizes: [.mobile: 4], [Styleguide.class([Class.type.align.end, Class.type.fontFamily.monospace])], [
+        gridColumn(sizes: [.mobile: 4], [`class`([Class.type.align.end, Class.type.fontFamily.monospace])], [
           div([.text(dateFormatter.string(from: invoice.date))])
           ]),
-        gridColumn(sizes: [.mobile: 2], [Styleguide.class([Class.type.align.end, Class.type.fontFamily.monospace])], [
+        gridColumn(sizes: [.mobile: 2], [`class`([Class.type.align.end, Class.type.fontFamily.monospace])], [
           div([.text(format(cents: invoice.total))])
           ]),
-        gridColumn(sizes: [.mobile: 2], [Styleguide.class([Class.grid.end(.mobile), Class.grid.end(.desktop)])], [
+        gridColumn(sizes: [.mobile: 2], [`class`([Class.grid.end(.mobile), Class.grid.end(.desktop)])], [
           div([
             a(
               [
-                Styleguide.class([Class.pf.components.button(color: .purple, size: .small)]),
+                `class`([Class.pf.components.button(color: .purple, size: .small)]),
                 href(invoice.id.map { path(to: .account(.invoices(.show($0)))) } ?? "#"),
                 target(.blank),
               ],
@@ -164,12 +164,12 @@ private func discountDescription(for discount: Stripe.Discount, invoice: Stripe.
 let invoiceView = View<(Stripe.Subscription, Database.User, Stripe.Invoice)> { subscription, currentUser, invoice -> Node in
 
   let discountRow = invoice.discount.map { discount in
-    gridRow([Styleguide.class([Class.padding([.mobile: [.topBottom: 1]])])], [
+    gridRow([`class`([Class.padding([.mobile: [.topBottom: 1]])])], [
       gridColumn(sizes: [.mobile: 2, .desktop: 8], [], []),
-      gridColumn(sizes: [.mobile: 6, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+      gridColumn(sizes: [.mobile: 6, .desktop: 2], [`class`([Class.type.align.end])], [
         div(["Discount"]),
         ]),
-      gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+      gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
         div([.text(discountDescription(for: discount, invoice: invoice))]),
         ]),
       ])
@@ -178,40 +178,40 @@ let invoiceView = View<(Stripe.Subscription, Database.User, Stripe.Invoice)> { s
   return gridRow([
     gridColumn(sizes: [.mobile: 12], [], [
       div(
-        [Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+        [`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
         [
-          gridRow([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+          gridRow([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             gridColumn(sizes: [.mobile: 12], [], [
               div(["Point-Free, Inc."]),
               div(["139 Skillman #5C"]),
               div(["Brooklyn, NY 11211"]),
               ]),
             ]),
-          gridRow([Styleguide.class([Class.padding([.mobile: [.topBottom: 3]])])], [
+          gridRow([`class`([Class.padding([.mobile: [.topBottom: 3]])])], [
             gridColumn(sizes: [.mobile: 12, .desktop: 6], [], [
               gridRow([
-                gridColumn(sizes: [.mobile: 12, .desktop: 2], [Styleguide.class([Class.type.bold])], [
+                gridColumn(sizes: [.mobile: 12, .desktop: 2], [`class`([Class.type.bold])], [
                   div(["Bill to"]),
                   ]),
-                gridColumn(sizes: [.mobile: 12, .desktop: 10], [Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+                gridColumn(sizes: [.mobile: 12, .desktop: 10], [`class`([Class.padding([.mobile: [.bottom: 1]])])], [
                   div([.text(currentUser.displayName)])
                   ]),
                 ]),
               ]),
             gridColumn(sizes: [.mobile: 12, .desktop: 6], [], [
               gridRow([
-                gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.type.bold])], [
+                gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.type.bold])], [
                   div(["Invoice number"]),
                   ]),
-                gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+                gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.padding([.mobile: [.bottom: 1]])])], [
                   div([.text(invoice.number.rawValue)]),
                   ]),
                 ]),
               gridRow([
-                gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.type.bold])], [
+                gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.type.bold])], [
                   div(["Billed on"]),
                   ]),
-                gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+                gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.padding([.mobile: [.bottom: 1]])])], [
                   div([.text(dateFormatter.string(from: invoice.date))]),
                   ]),
                 ]),
@@ -220,10 +220,10 @@ let invoiceView = View<(Stripe.Subscription, Database.User, Stripe.Invoice)> { s
                 invoice.charge?.right.map {
                   [
                     gridRow([
-                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.type.bold])], [
+                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.type.bold])], [
                         div(["Payment method"]),
                         ]),
-                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.padding([.mobile: [.bottom: 1]])])], [
                         div([.text($0.source.brand.rawValue + " ⋯ \($0.source.last4)")]),
                         ]),
                       ])
@@ -235,10 +235,10 @@ let invoiceView = View<(Stripe.Subscription, Database.User, Stripe.Invoice)> { s
                 subscription.customer.right?.businessVatId.map {
                   [
                     gridRow([
-                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.type.bold])], [
+                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.type.bold])], [
                         div(["VAT"]),
                         ]),
-                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+                      gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.padding([.mobile: [.bottom: 1]])])], [
                         div([.text($0.rawValue)]),
                         ]),
                       ])
@@ -249,72 +249,72 @@ let invoiceView = View<(Stripe.Subscription, Database.User, Stripe.Invoice)> { s
               <> extraInvoiceInfo(subscription: subscription)
             ),
             ]),
-          gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]]), Class.type.bold])], [
+          gridRow([`class`([Class.padding([.mobile: [.bottom: 2]]), Class.type.bold])], [
             gridColumn(sizes: [.mobile: 4, .desktop: 6], [], [
               div(["Description"]),
               ]),
-            gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+            gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
               div(["Quantity"]),
               ]),
-            gridColumn(sizes: [.mobile: 0, .desktop: 2], [Styleguide.class([Class.type.align.end, Class.hide(.mobile)])], [
+            gridColumn(sizes: [.mobile: 0, .desktop: 2], [`class`([Class.type.align.end, Class.hide(.mobile)])], [
               div(["Unit price"]),
               ]),
-            gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+            gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
               div(["Amount"]),
               ]),
             ]),
           ]
           <> invoice.lines.data.map { item in
-            gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+            gridRow([`class`([Class.padding([.mobile: [.bottom: 1]])])], [
               gridColumn(sizes: [.mobile: 6, .desktop: 6], [], [
                 div([.text(item.description ?? subscription.plan.name)])
                 ]),
-              gridColumn(sizes: [.mobile: 2, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 2, .desktop: 2], [`class`([Class.type.align.end])], [
                 div([.text("\(item.quantity)")]),
                 ]),
-              gridColumn(sizes: [.mobile: 0], [Styleguide.class([Class.type.align.end, Class.hide(.mobile)])], [
+              gridColumn(sizes: [.mobile: 0], [`class`([Class.type.align.end, Class.hide(.mobile)])], [
                 div([.text(format(cents: item.amount))]),
                 ]),
-              gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
                 div([.text(format(cents: item.amount))]),
                 ]),
               ])
           }
           <> [
-            gridRow([Styleguide.class([Class.padding([.mobile: [.topBottom: 1]])])], [
+            gridRow([`class`([Class.padding([.mobile: [.topBottom: 1]])])], [
               gridColumn(sizes: [.mobile: 2, .desktop: 8], [], []),
-              gridColumn(sizes: [.mobile: 6, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 6, .desktop: 2], [`class`([Class.type.align.end])], [
                 div(["Subtotal"]),
                 ]),
-              gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
                 div([.text(format(cents: invoice.subtotal))]),
                 ]),
               ])
             ] + [discountRow].compactMap(id) + [
-            gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+            gridRow([`class`([Class.padding([.mobile: [.bottom: 1]])])], [
               gridColumn(sizes: [.mobile: 2, .desktop: 8], [], []),
-              gridColumn(sizes: [.mobile: 6, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 6, .desktop: 2], [`class`([Class.type.align.end])], [
                 div(["Total"]),
                 ]),
-              gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
                 div([.text(format(cents: invoice.total))]),
                 ]),
               ]),
-            gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+            gridRow([`class`([Class.padding([.mobile: [.bottom: 1]])])], [
               gridColumn(sizes: [.mobile: 2, .desktop: 8], [], []),
-              gridColumn(sizes: [.mobile: 6, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 6, .desktop: 2], [`class`([Class.type.align.end])], [
                 div(["Amount paid"]),
                 ]),
-              gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
                 div([.text(format(cents: -invoice.amountPaid))]),
                 ]),
               ]),
-            gridRow([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]]), Class.type.bold])], [
+            gridRow([`class`([Class.padding([.mobile: [.topBottom: 2]]), Class.type.bold])], [
               gridColumn(sizes: [.mobile: 2, .desktop: 8], [], []),
-              gridColumn(sizes: [.mobile: 6, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 6, .desktop: 2], [`class`([Class.type.align.end])], [
                 div(["Amount due"]),
                 ]),
-              gridColumn(sizes: [.mobile: 4, .desktop: 2], [Styleguide.class([Class.type.align.end])], [
+              gridColumn(sizes: [.mobile: 4, .desktop: 2], [`class`([Class.type.align.end])], [
                 div([.text(format(cents: invoice.amountDue))]),
                 ]),
               ]),
@@ -327,7 +327,7 @@ let invoiceView = View<(Stripe.Subscription, Database.User, Stripe.Invoice)> { s
 private func extraInvoiceInfo(subscription: Stripe.Subscription) -> [Node] {
   guard let extraInvoiceInfo = subscription.customer.right?.extraInvoiceInfo else { return [] }
 
-  let extraInvoiceInfoNodes = intersperse(Html.br)
+  let extraInvoiceInfoNodes = intersperse(br)
     <| extraInvoiceInfo
       .components(separatedBy: CharacterSet.newlines)
       .filter { !$0.isEmpty }
@@ -335,10 +335,10 @@ private func extraInvoiceInfo(subscription: Stripe.Subscription) -> [Node] {
 
   return [
     gridRow([
-      gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.type.bold])], [
+      gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.type.bold])], [
         div(["User Info"]),
         ]),
-      gridColumn(sizes: [.mobile: 12, .desktop: 6], [Styleguide.class([Class.padding([.mobile: [.bottom: 1]])])], [
+      gridColumn(sizes: [.mobile: 12, .desktop: 6], [`class`([Class.padding([.mobile: [.bottom: 1]])])], [
         div(
           extraInvoiceInfoNodes
         )

--- a/Sources/PointFree/Account/PaymentInfo.swift
+++ b/Sources/PointFree/Account/PaymentInfo.swift
@@ -63,7 +63,7 @@ let paymentInfoView = View<(Stripe.Subscription, PricingFormStyle)> { subscripti
 
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 8], [style(margin(leftRight: .auto))], [
-      div([Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+      div([`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
           titleRowView.view(unit)
             <> (subscription.customer.right?.sources.data.first.map(currentPaymentInfoRowView.view) ?? [])
             <> updatePaymentInfoRowView.view(formFields)
@@ -73,20 +73,20 @@ let paymentInfoView = View<(Stripe.Subscription, PricingFormStyle)> { subscripti
 }
 
 private let titleRowView = View<Prelude.Unit> { _ in
-  gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+  gridRow([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h1([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Payment Info"])
+        h1([`class`([Class.pf.type.responsiveTitle3])], ["Payment Info"])
         ])
       ])
     ])
 }
 
 private let currentPaymentInfoRowView = View<Stripe.Card> { card in
-  gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+  gridRow([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h2([Styleguide.class([Class.pf.type.responsiveTitle4])], ["Current Payment Info"]),
+        h2([`class`([Class.pf.type.responsiveTitle4])], ["Current Payment Info"]),
         p([.text(card.brand.rawValue + " ending in " + String(card.last4))]),
         p([.text("Expires " + String(card.expMonth) + "/" + String(card.expYear))]),
         ])
@@ -95,10 +95,10 @@ private let currentPaymentInfoRowView = View<Stripe.Card> { card in
 }
 
 private let updatePaymentInfoRowView = View<PricingFormStyle> { formStyle in
-  return gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 4]])])], [
+  return gridRow([`class`([Class.padding([.mobile: [.bottom: 4]])])], [
     gridColumn(sizes: [.mobile: 12], [
       div([
-        h2([Styleguide.class([Class.pf.type.responsiveTitle4])], ["Update"]),
+        h2([`class`([Class.pf.type.responsiveTitle4])], ["Update"]),
         form(
           [action(path(to: .account(.paymentInfo(.update(nil))))), id(Stripe.html.formId), method(.post)],
           Stripe.html.cardInput(couponId: nil, formStyle: formStyle)
@@ -106,13 +106,13 @@ private let updatePaymentInfoRowView = View<PricingFormStyle> { formStyle in
             <> Stripe.html.scripts
             <> [
               button(
-                [Styleguide.class([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])])],
+                [`class`([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])])],
                 ["Update payment info"]
               ),
               a(
                 [
                   href(path(to: .account(.index))),
-                  Styleguide.class([Class.pf.components.button(color: .black, style: .underline)])
+                  `class`([Class.pf.components.button(color: .black, style: .underline)])
                 ],
                 ["Cancel"]
               )

--- a/Sources/PointFree/Blog/BlogPostIndex.swift
+++ b/Sources/PointFree/Blog/BlogPostIndex.swift
@@ -39,7 +39,7 @@ private let blogIndexView = View<(Database.User?, SubscriberState)> { currentUse
   let oldPosts = allPosts.dropFirst(3)
 
   return gridRow(
-    [Styleguide.class([Class.padding([.mobile: [.leftRight: 3], .desktop: [.leftRight: 4]])])],
+    [`class`([Class.padding([.mobile: [.leftRight: 3], .desktop: [.leftRight: 4]])])],
     [
       gridColumn(
         sizes: [.mobile: 12, .desktop: 9],
@@ -54,7 +54,7 @@ private let blogIndexView = View<(Database.User?, SubscriberState)> { currentUse
 private let newBlogPostView = View<BlogPost> { post in
   [
     div(
-      [Styleguide.class([Class.padding([.mobile: [.topBottom: 3], .desktop: [.topBottom: 4]])])],
+      [`class`([Class.padding([.mobile: [.topBottom: 3], .desktop: [.topBottom: 4]])])],
       blogPostContentView.view(post)
     ),
     divider
@@ -66,12 +66,12 @@ private let oldBlogPostsView = View<ArraySlice<BlogPost>> { posts -> [Node] in
   
   return [
     div(
-      [Styleguide.class([Class.padding([.mobile: [.top: 4, .bottom: 2]])])],
-      [h5([Styleguide.class([Class.pf.type.responsiveTitle6])], ["Older blog posts"])]
+      [`class`([Class.padding([.mobile: [.top: 4, .bottom: 2]])])],
+      [h5([`class`([Class.pf.type.responsiveTitle6])], ["Older blog posts"])]
     ),
 
     div(
-      [Styleguide.class([Class.padding([.mobile: [.bottom: 3]])])],
+      [`class`([Class.padding([.mobile: [.bottom: 3]])])],
       posts.flatMap(oldBlogPostView.view)
     )
   ]
@@ -80,19 +80,19 @@ private let oldBlogPostsView = View<ArraySlice<BlogPost>> { posts -> [Node] in
 private let oldBlogPostView = View<BlogPost> { post in
   [
     div(
-      [Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])],
+      [`class`([Class.padding([.mobile: [.topBottom: 2]])])],
       [
         div(
           [
             p(
-              [Styleguide.class([Class.pf.colors.fg.gray400, Class.pf.type.body.small])],
+              [`class`([Class.pf.colors.fg.gray400, Class.pf.type.body.small])],
               [.text(episodeDateFormatter.string(from: post.publishedAt))]
             )
           ]
         ),
 
         h1(
-          [Styleguide.class([Class.pf.type.responsiveTitle5]),],
+          [`class`([Class.pf.type.responsiveTitle5]),],
           [
             a(
               [href(url(to: .blog(.show(post))))],
@@ -104,7 +104,7 @@ private let oldBlogPostView = View<BlogPost> { post in
         div(
           [
             p(
-              [Styleguide.class([Class.pf.type.body.regular])],
+              [`class`([Class.pf.type.body.regular])],
               [.text(post.blurb)]
             )
           ]

--- a/Sources/PointFree/Blog/BlogPostShow.swift
+++ b/Sources/PointFree/Blog/BlogPostShow.swift
@@ -44,14 +44,14 @@ private let blogPostShowView = View<(BlogPost, SubscriberState)> { post, subscri
 
   [
     gridRow(
-      [Styleguide.class([Class.padding([.mobile: [.leftRight: 3], .desktop: [.leftRight: 4]])])],
+      [`class`([Class.padding([.mobile: [.leftRight: 3], .desktop: [.leftRight: 4]])])],
       [
         gridColumn(
           sizes: [.mobile: 12, .desktop: 9],
           [style(margin(leftRight: .auto))],
           [
             div(
-              [Styleguide.class([Class.padding([.mobile: [.topBottom: 3], .desktop: [.topBottom: 4]])])],
+              [`class`([Class.padding([.mobile: [.topBottom: 3], .desktop: [.topBottom: 4]])])],
               blogPostContentView.view(post)
                 <> subscriberCalloutView.view(subscriberState)
             )
@@ -66,7 +66,7 @@ private let subscriberCalloutView = View<SubscriberState> { subscriberState -> [
   guard !subscriberState.isActive else { return [] }
 
   return [
-    hr([Styleguide.class([Class.pf.components.divider, Class.margin([.mobile: [.topBottom: 4]])])]),
+    hr([`class`([Class.pf.components.divider, Class.margin([.mobile: [.topBottom: 4]])])]),
 
     div(
       [
@@ -97,7 +97,7 @@ private let subscriberCalloutView = View<SubscriberState> { subscriberState -> [
             a(
               [
                 href(path(to: .home)),
-                Styleguide.class([Class.pf.type.underlineLink])
+                `class`([Class.pf.type.underlineLink])
               ],
               ["Point-Free"]
             ),
@@ -112,7 +112,7 @@ private let subscriberCalloutView = View<SubscriberState> { subscriberState -> [
 let blogPostContentView = View<BlogPost> { post in
   [
     h1(
-      [Styleguide.class([Class.pf.type.responsiveTitle3]),],
+      [`class`([Class.pf.type.responsiveTitle3]),],
       [
         a(
           [href(url(to: .blog(.show(post))))],
@@ -123,13 +123,13 @@ let blogPostContentView = View<BlogPost> { post in
 
     div(
       [
-        Styleguide.class([Class.flex.flex, Class.flex.items.baseline]),
+        `class`([Class.flex.flex, Class.flex.items.baseline]),
         style(flex(direction: .row))
       ],
       [
         div([p([.text(episodeDateFormatter.string(from: post.publishedAt))])]),
         div(
-          [Styleguide.class([Class.margin([.mobile: [.left: 1]])])],
+          [`class`([Class.margin([.mobile: [.left: 1]])])],
           [twitterShareLink(text: post.title, url: url(to: .blog(.show(post))), via: "pointfreeco")]
         )
       ]
@@ -149,7 +149,7 @@ let blogPostContentView = View<BlogPost> { post in
     ),
 
     div(
-      [Styleguide.class([Class.pf.colors.bg.white])],
+      [`class`([Class.pf.colors.bg.white])],
       post.contentBlocks.flatMap(transcriptBlockView.view)
     )
   ]

--- a/Sources/PointFree/Components.swift
+++ b/Sources/PointFree/Components.swift
@@ -35,7 +35,7 @@ func gitHubLink(text: String, type: GitHubLinkType, redirect: String?) -> Node {
   return a(
     [
       href(path(to: .login(redirect: redirect))),
-      Styleguide.class([type.buttonClass])
+      `class`([type.buttonClass])
     ],
     [
       img(
@@ -43,7 +43,7 @@ func gitHubLink(text: String, type: GitHubLinkType, redirect: String?) -> Node {
         type: .image(.svg),
         alt: "",
         [
-          Styleguide.class([Class.margin([.mobile: [.right: 1]])]),
+          `class`([Class.margin([.mobile: [.right: 1]])]),
           style(margin(bottom: .px(-4))),
           width(20),
           height(20)
@@ -79,7 +79,7 @@ func twitterShareLink(text: String, url: String, via: String? = nil) -> Node {
       """),
       target(.blank),
       rel(.init(rawValue: "noopener noreferrer")),
-      Styleguide.class([twitterLinkButtonClass]),
+      `class`([twitterLinkButtonClass]),
       style(twitterLinkButtonStyle)
     ],
     [
@@ -89,11 +89,11 @@ func twitterShareLink(text: String, url: String, via: String? = nil) -> Node {
         alt: "",
         [
           style(twitterButtonIconStyle),
-          Styleguide.class([twitterButtonIconClass])
+          `class`([twitterButtonIconClass])
         ]
       ),
       span(
-        [style(twitterButtonTextStyle), Styleguide.class([twitterButtonTextClass])],
+        [style(twitterButtonTextStyle), `class`([twitterButtonTextClass])],
         ["Tweet"]
       )
     ]

--- a/Sources/PointFree/Emails/AdminEmailReport.swift
+++ b/Sources/PointFree/Emails/AdminEmailReport.swift
@@ -28,8 +28,8 @@ let adminEmailReportContent = View<(String, [Database.User], Int)> { type, error
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 1], .desktop: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["New episode email report"]),
+        div([`class`([Class.padding([.mobile: [.all: 1], .desktop: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["New episode email report"]),
           p([
             "A total of ",
             strong([.text("\(totalAttempted)")]),

--- a/Sources/PointFree/Emails/ChangeEmailConfirmation.swift
+++ b/Sources/PointFree/Emails/ChangeEmailConfirmation.swift
@@ -21,25 +21,25 @@ private let confirmEmailChangeEmailBody = View<(Database.User, EmailAddress)> { 
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Confirm email change"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Confirm email change"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             "We received a request to change your email on Point-Free. Your current email is ",
-            span([Styleguide.class([Class.type.semiBold])], [.text(user.email.rawValue)]),
+            span([`class`([Class.type.semiBold])], [.text(user.email.rawValue)]),
             ", and the new email is ",
-            span([Styleguide.class([Class.type.semiBold])], [.text(newEmailAddress.rawValue)]),
+            span([`class`([Class.type.semiBold])], [.text(newEmailAddress.rawValue)]),
             ". If you want to make this change, just click the confirmation link below:"
             ]),
 
-          p([Styleguide.class([Class.padding([.mobile: [.top: 2, .bottom: 3]])])], [
+          p([`class`([Class.padding([.mobile: [.top: 2, .bottom: 3]])])], [
             a(
               [ href(url(to: .account(.confirmEmailChange(userId: user.id, emailAddress: newEmailAddress)))),
-                Styleguide.class([Class.pf.components.button(color: .purple)]) ],
+                `class`([Class.pf.components.button(color: .purple)]) ],
               ["Confirm email change"]
             )
             ]),
 
-          p([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+          p([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
             """
             If you do not want to make this change, or did not request to make this change, simply ignore
             this email.
@@ -67,11 +67,11 @@ private let emailChangedEmailBody = View<EmailAddress> { newEmailAddress in
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Your email has been changed"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Your email has been changed"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             "Your email has been successfully changed to ",
-            strong([span([Styleguide.class([Class.type.semiBold])], [.text(newEmailAddress.rawValue)])]),
+            strong([span([`class`([Class.type.semiBold])], [.text(newEmailAddress.rawValue)])]),
             ". If you did not make this change, please get in touch with us immediately: ",
             a([mailto("support@pointfree.co")], ["support@pointfree.co"])
             ])

--- a/Sources/PointFree/Emails/FreeEpisodeEmail.swift
+++ b/Sources/PointFree/Emails/FreeEpisodeEmail.swift
@@ -30,7 +30,7 @@ let freeEpisodeEmailContent = View<Episode> { ep in
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])], [
           blockquote(
             [
               `class`(
@@ -52,26 +52,26 @@ let freeEpisodeEmailContent = View<Episode> { ep in
 
           a([href(url(to: .episode(.left(ep.slug))))], [
             h3(
-              [Styleguide.class([Class.pf.type.responsiveTitle3])],
+              [`class`([Class.pf.type.responsiveTitle3])],
               [.text("Episode #\(ep.sequence) is now free!")]
             )
             ]),
 
           h4(
-            [Styleguide.class([Class.pf.type.responsiveTitle5])],
+            [`class`([Class.pf.type.responsiveTitle5])],
             [.text(ep.title)]
           ),
 
           p([.text(ep.blurb)]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             a([href(url(to: .episode(.left(ep.slug))))], [
               img([src(ep.image), alt(""), style(maxWidth(.pct(100)))])
               ])
             ]),
 
           p([.text("This episode is \(ep.length / 60) minutes long.")]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
-            a([href(url(to: .episode(.left(ep.slug)))), Styleguide.class([Class.pf.components.button(color: .purple)])],
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
+            a([href(url(to: .episode(.left(ep.slug)))), `class`([Class.pf.components.button(color: .purple)])],
               ["Watch now!"])
             ])
           ]

--- a/Sources/PointFree/Emails/InviteEmail.swift
+++ b/Sources/PointFree/Emails/InviteEmail.swift
@@ -21,9 +21,9 @@ private let teamInviteEmailBodyView = View<(Database.User, Database.TeamInvite)>
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["You’re invited!"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["You’re invited!"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             "Your colleague ",
             .text(inviter.displayName),
             """
@@ -31,10 +31,10 @@ private let teamInviteEmailBodyView = View<(Database.User, Database.TeamInvite)>
             programming and the Swift programming language. To accept, simply click the link below!
             """
             ]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             a([
               href(url(to: .invite(.show(invite.id)))),
-              Styleguide.class([Class.pf.components.button(color: .purple)])
+              `class`([Class.pf.components.button(color: .purple)])
               ],
               ["Click here to accept!"])
             ])
@@ -60,7 +60,7 @@ private let inviteeAcceptedEmailBodyView = View<(Database.User, Database.User)> 
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        h3([Styleguide.class([Class.pf.type.responsiveTitle3]), Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+        h3([`class`([Class.pf.type.responsiveTitle3]), `class`([Class.padding([.mobile: [.bottom: 2]])])], [
           "Your invitation was accepted!"
           ]),
         p([

--- a/Sources/PointFree/Emails/NewBlogPostEmail.swift
+++ b/Sources/PointFree/Emails/NewBlogPostEmail.swift
@@ -32,20 +32,20 @@ let newBlogPostEmailContent = View<(BlogPost, String?)> { post, announcement -> 
     tr([
       td([valign(.top)], [
         div(
-          [Styleguide.class([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])],
+          [`class`([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])],
           announcementView.view(announcement)
         ),
 
-        div([Styleguide.class([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])], [
           a([href(url(to: .blog(.show(post))))], [
-            h3([Styleguide.class([Class.pf.type.responsiveTitle3])], [.text(post.title)]),
+            h3([`class`([Class.pf.type.responsiveTitle3])], [.text(post.title)]),
             ]),
             p([text(post.blurb)])
           ]
           + (
             post.coverImage.map {
               [
-                p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+                p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
                   a([href(url(to: .blog(.show(post))))], [
                     img([src($0), alt(""), style(maxWidth(.pct(100)))])
                     ])
@@ -69,7 +69,7 @@ let newBlogPostEmailContent = View<(BlogPost, String?)> { post, announcement -> 
           ]),
 
         div(
-          [Styleguide.class([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])],
+          [`class`([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])],
           hostSignOffView.view(unit)
         )
         ])
@@ -93,7 +93,7 @@ private let announcementView = View<String?> { announcement -> [Node] in
         )
       ],
       [
-        h5([Styleguide.class([Class.pf.type.responsiveTitle5])], ["Announcements"]),
+        h5([`class`([Class.pf.type.responsiveTitle5])], ["Announcements"]),
         markdownBlock(announcement)
       ]
     )
@@ -116,8 +116,8 @@ let newBlogPostEmailAdminReportEmailContent = View<([Database.User], Int)> { err
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 1], .desktop: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["New blog post email report"]),
+        div([`class`([Class.padding([.mobile: [.all: 1], .desktop: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["New blog post email report"]),
           p([
             "A total of ",
             strong([.text("\(totalAttempted)")]),

--- a/Sources/PointFree/Emails/NewEpisodeEmail.swift
+++ b/Sources/PointFree/Emails/NewEpisodeEmail.swift
@@ -32,15 +32,15 @@ let newEpisodeEmailContent = View<(Episode, String?, isSubscriber: Bool)> { ep, 
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])],
+        div([`class`([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])],
 
             announcementView.view(announcement) <> [
 
               a([href(url(to: .episode(.left(ep.slug))))], [
-                h3([Styleguide.class([Class.pf.type.responsiveTitle3])], [.text("#\(ep.sequence): \(ep.title)")]),
+                h3([`class`([Class.pf.type.responsiveTitle3])], [.text("#\(ep.sequence): \(ep.title)")]),
                 ]),
               p([.text(ep.blurb)]),
-              p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+              p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
                 a([href(url(to: .episode(.left(ep.slug))))], [
                   img([src(ep.image), alt(""), style(maxWidth(.pct(100)))])
                   ])
@@ -70,7 +70,7 @@ private let announcementView = View<String?> { announcement -> [Node] in
         )
       ],
       [
-        h5([Styleguide.class([Class.pf.type.responsiveTitle5])], ["Announcements"]),
+        h5([`class`([Class.pf.type.responsiveTitle5])], ["Announcements"]),
         markdownBlock(announcement)
       ]
     )
@@ -90,14 +90,14 @@ private let nonSubscriberCtaView = View<(Episode, isSubscriber: Bool)> { ep, isS
 
   return [
     p([.text(blurb)]),
-    p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
-      a([href(url(to: .pricing(nil, expand: nil))), Styleguide.class([Class.pf.components.button(color: .purple)])],
+    p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
+      a([href(url(to: .pricing(nil, expand: nil))), `class`([Class.pf.components.button(color: .purple)])],
         ["Subscribe to Point-Free!"]
       ),
       a(
         [
           href(url(to: .episode(.left(ep.slug)))),
-            Styleguide.class([Class.pf.components.button(color: .black, style: .underline), Class.display.inlineBlock])
+            `class`([Class.pf.components.button(color: .black, style: .underline), Class.display.inlineBlock])
         ],
         [.text(watchText)]
       )
@@ -110,8 +110,8 @@ private let subscriberCtaView = View<(Episode, isSubscriber: Bool)> { (ep, isSub
 
   return [
     p([.text("This episode is \(ep.length / 60) minutes long.")]),
-    p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
-      a([href(url(to: .episode(.left(ep.slug)))), Styleguide.class([Class.pf.components.button(color: .purple)])],
+    p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
+      a([href(url(to: .episode(.left(ep.slug)))), `class`([Class.pf.components.button(color: .purple)])],
         ["Watch now!"])
       ])
   ]

--- a/Sources/PointFree/Emails/RegistrationEmail.swift
+++ b/Sources/PointFree/Emails/RegistrationEmail.swift
@@ -21,21 +21,21 @@ private let registrationEmailBody = View<GitHub.User> { user in
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Thanks for signing up!"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Thanks for signing up!"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             "You’re one step closer to our video series!"
             ]),
 
-          p([Styleguide.class([Class.padding([.mobile: [.bottom: 2]])])], [
+          p([`class`([Class.padding([.mobile: [.bottom: 2]])])], [
             """
             To get all that Point-Free has to offer, choose from one of our monthly or yearly plans by clicking
             the link below!
             """
             ]),
 
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
-            a([href(url(to: .pricing(nil, expand: nil))), Styleguide.class([Class.pf.components.button(color: .purple)])],
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
+            a([href(url(to: .pricing(nil, expand: nil))), `class`([Class.pf.components.button(color: .purple)])],
               ["Choose a subscription plan!"])
             ])
           ])

--- a/Sources/PointFree/Emails/SharedEmailComponents.swift
+++ b/Sources/PointFree/Emails/SharedEmailComponents.swift
@@ -7,7 +7,7 @@ import View
 
 let hostSignOffView = View<Prelude.Unit> { _ in
   [
-    p([Styleguide.class([Class.padding([.mobile: [.top: 2]])])], [
+    p([`class`([Class.padding([.mobile: [.top: 2]])])], [
       "Your hosts,"
       ]),
     p([
@@ -19,11 +19,11 @@ let hostSignOffView = View<Prelude.Unit> { _ in
 }
 
 let emailFooterView = View<(Database.User?, Database.EmailSetting.Newsletter?)> { user, newsletter in
-  emailTable([Styleguide.class([Class.pf.colors.bg.gray900]), style(contentTableStyles)], [
+  emailTable([`class`([Class.pf.colors.bg.gray900]), style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          p([Styleguide.class([Class.pf.type.body.small])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          p([`class`([Class.pf.type.body.small])], [
             "Contact us via email at ",
             a([mailto("support@pointfree.co")], ["support@pointfree.co"]),
             ", or on Twitter ",
@@ -31,7 +31,7 @@ let emailFooterView = View<(Database.User?, Database.EmailSetting.Newsletter?)> 
             "."
             ]),
 
-          p([Styleguide.class([Class.pf.type.body.small])], [
+          p([`class`([Class.pf.type.body.small])], [
             "Our postal address: 139 Skillman #5C, Brooklyn, NY 11211"
             ]),
 
@@ -45,7 +45,7 @@ private let unsubscribeView = View<(Database.User?, Database.EmailSetting.Newsle
   guard let user = user, let newsletter = newsletter else { return [] }
 
   return [
-    p([Styleguide.class([Class.pf.type.body.small])], [
+    p([`class`([Class.pf.type.body.small])], [
       .text(subscribedReason(newsletter: newsletter)),
       " If you no longer wish to receive emails like this, you can unsubscribe ",
       a([href(url(to: .expressUnsubscribe(userId: user.id, newsletter: newsletter)))], ["here"]),

--- a/Sources/PointFree/Emails/TeamEmails.swift
+++ b/Sources/PointFree/Emails/TeamEmails.swift
@@ -21,9 +21,9 @@ private let youHaveBeenRemovedEmailBody = View<(Database.User, Database.User)> {
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Team removal"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Team removal"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             .text("""
               You have been removed from \(teamOwner.displayName)’s Point-Free team, which means you no longer
               have access to full episodes and transcripts. If you wish to subscribe to an individual plan,
@@ -31,10 +31,10 @@ private let youHaveBeenRemovedEmailBody = View<(Database.User, Database.User)> {
               """)
             ]),
 
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             a([
               href(url(to: .pricing(nil, expand: nil))),
-              Styleguide.class([Class.pf.components.button(color: .purple)])
+              `class`([Class.pf.components.button(color: .purple)])
               ],
               ["See subscription plans"])
             ])
@@ -60,9 +60,9 @@ private let teammateRemovedEmailBody = View<(Database.User, Database.User)> { te
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Team removal"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Team removal"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             .text("""
               You have removed \(teammate.displayName) from your Point-Free team, which means they no longer
               have access to full episodes and transcripts. You can add them back anytime from your account
@@ -70,10 +70,10 @@ private let teammateRemovedEmailBody = View<(Database.User, Database.User)> { te
               """)
             ]),
 
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             a([
               href(url(to: .account(.index))),
-              Styleguide.class([Class.pf.components.button(color: .purple)])
+              `class`([Class.pf.components.button(color: .purple)])
               ],
               ["Account settings"])
             ])

--- a/Sources/PointFree/Episode/Show.swift
+++ b/Sources/PointFree/Episode/Show.swift
@@ -160,7 +160,7 @@ private let episodeView = View<(EpisodePermission, Database.User?, SubscriberSta
 
   [
     gridRow([
-      gridColumn(sizes: [.mobile: 12], [Styleguide.class([Class.hide(.desktop)])], [
+      gridColumn(sizes: [.mobile: 12], [`class`([Class.hide(.desktop)])], [
         div(episodeInfoView.view((permission, episode)))
         ])
       ]),
@@ -173,10 +173,10 @@ private let episodeView = View<(EpisodePermission, Database.User?, SubscriberSta
 
       gridColumn(
         sizes: [.mobile: 12, .desktop: 6],
-        [Styleguide.class([Class.pf.colors.bg.purple150, Class.grid.first(.mobile), Class.grid.last(.desktop)])],
+        [`class`([Class.pf.colors.bg.purple150, Class.grid.first(.mobile), Class.grid.last(.desktop)])],
         [
           div(
-            [Styleguide.class([Class.position.sticky(.desktop), Class.position.top0])],
+            [`class`([Class.position.sticky(.desktop), Class.position.top0])],
             rightColumnView.view(
               (episode, isEpisodeViewable(for: permission))
             )
@@ -217,14 +217,14 @@ private let rightColumnView = View<(Episode, Bool)> { episode, isEpisodeViewable
 private let videoView = View<(Episode, isEpisodeViewable: Bool)> { episode, isEpisodeViewable in
   div(
     [
-      Styleguide.class([outerVideoContainerClass]),
+      `class`([outerVideoContainerClass]),
       style(outerVideoContainerStyle)
     ],
     [
       video(
         [
-          Html.id("episode-video"),
-          Styleguide.class([
+          id("episode-video"),
+          `class`([
             innerVideoContainerClass,
             videoJsClasses
             ]),
@@ -249,9 +249,9 @@ private let videoView = View<(Episode, isEpisodeViewable: Bool)> { episode, isEp
 }
 
 private let episodeTocView = View<(blocks: [Episode.TranscriptBlock], isEpisodeViewable: Bool)> { blocks, isEpisodeViewable in
-  div([Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.leftRight: 4]])])], [
+  div([`class`([Class.padding([.mobile: [.all: 3], .desktop: [.leftRight: 4]])])], [
     h6(
-      [Styleguide.class([Class.pf.type.responsiveTitle8, Class.pf.colors.fg.gray850, Class.padding([.mobile: [.bottom: 1]])])],
+      [`class`([Class.pf.type.responsiveTitle8, Class.pf.colors.fg.gray850, Class.padding([.mobile: [.bottom: 1]])])],
       ["Chapters"]
     ),
     ]
@@ -293,7 +293,7 @@ private let tocChapterView = View<(title: String, timestamp: Int, isEpisodeViewa
 
     gridColumn(sizes: [.mobile: 2], [
       div(
-        [Styleguide.class([Class.pf.colors.fg.purple, Class.type.align.end, Class.pf.opacity75])],
+        [`class`([Class.pf.colors.fg.purple, Class.type.align.end, Class.pf.opacity75])],
         [.text(timestampLabel(for: timestamp))]
       )
       ])
@@ -304,18 +304,18 @@ private let tocChapterLinkView = View<(title: String, timestamp: Int, active: Bo
   if active {
     return
       [
-        div([Styleguide.class([Class.hide(.mobile)])], [
+        div([`class`([Class.hide(.mobile)])], [
           a(
             timestampLinkAttributes(timestamp: timestamp, useAnchors: true) +
-              [Styleguide.class([Class.pf.colors.link.green, Class.type.textDecorationNone, Class.pf.type.body.regular])],
+              [`class`([Class.pf.colors.link.green, Class.type.textDecorationNone, Class.pf.type.body.regular])],
             [.text(title)]
           )
           ]),
 
-        div([Styleguide.class([Class.hide(.desktop)])], [
+        div([`class`([Class.hide(.desktop)])], [
           a(
             timestampLinkAttributes(timestamp: timestamp, useAnchors: false) +
-              [Styleguide.class([Class.pf.colors.link.green, Class.type.textDecorationNone, Class.pf.type.body.regular])],
+              [`class`([Class.pf.colors.link.green, Class.type.textDecorationNone, Class.pf.type.body.regular])],
             [.text(title)]
           )
           ]),
@@ -324,7 +324,7 @@ private let tocChapterLinkView = View<(title: String, timestamp: Int, active: Bo
 
   return [
     div(
-      [Styleguide.class([Class.pf.colors.fg.green, Class.pf.type.body.regular])],
+      [`class`([Class.pf.colors.fg.green, Class.pf.type.body.regular])],
       [.text(title)]
     )
   ]
@@ -334,22 +334,22 @@ private let downloadsView = View<String> { codeSampleDirectory -> [Node] in
   guard !codeSampleDirectory.isEmpty else { return [] }
 
   return [
-    div([Styleguide.class([Class.padding([.mobile: [.leftRight: 3], .desktop: [.leftRight: 4]]), Class.padding([.mobile: [.bottom: 3]])])],
+    div([`class`([Class.padding([.mobile: [.leftRight: 3], .desktop: [.leftRight: 4]]), Class.padding([.mobile: [.bottom: 3]])])],
         [
           h6(
-            [Styleguide.class([Class.pf.type.responsiveTitle8, Class.pf.colors.fg.gray850, Class.padding([.mobile: [.bottom: 1]])])],
+            [`class`([Class.pf.type.responsiveTitle8, Class.pf.colors.fg.gray850, Class.padding([.mobile: [.bottom: 1]])])],
             ["Downloads"]
           ),
           img(
             base64: gitHubSvgBase64(fill: "#FFF080"),
             type: .image(.svg),
             alt: "",
-            [Styleguide.class([Class.align.middle]), width(20), height(20)]
+            [`class`([Class.align.middle]), width(20), height(20)]
           ),
           a(
             [
               href(gitHubUrl(to: GitHubRoute.episodeCodeSample(directory: codeSampleDirectory))),
-              Styleguide.class([Class.pf.colors.link.yellow, Class.margin([.mobile: [.left: 1]]), Class.align.middle])
+              `class`([Class.pf.colors.link.yellow, Class.margin([.mobile: [.left: 1]]), Class.align.middle])
             ],
             [.text("\(codeSampleDirectory).playground")]
           )
@@ -375,7 +375,7 @@ private let leftColumnView = View<(EpisodePermission, Database.User?, Subscriber
   let transcriptNodes = transcriptView.view((episode.transcriptBlocks, isEpisodeViewable(for: permission)))
 
   return div(
-    [div([Styleguide.class([Class.hide(.mobile)])], episodeInfoView.view((permission, episode)))]
+    [div([`class`([Class.hide(.mobile)])], episodeInfoView.view((permission, episode)))]
       + dividerView.view(unit)
       + subscribeNodes
       + transcriptNodes
@@ -453,7 +453,7 @@ private let creditBlurb = View<(EpisodePermission, Episode)> { permission, episo
         input(
           [
             type(.submit),
-            Styleguide.class([Class.pf.components.button(color: .black, size: .small)]),
+            `class`([Class.pf.components.button(color: .black, size: .small)]),
             value(useCreditCTA)
           ]
         )
@@ -473,7 +473,7 @@ private let signUpBlurb = View<(EpisodePermission, Episode)> { permission, episo
 
   return [
     p(
-      [Styleguide.class([Class.pf.type.body.regular, Class.padding([.mobile: [.top: 4, .bottom: 2]])])],
+      [`class`([Class.pf.type.body.regular, Class.padding([.mobile: [.top: 4, .bottom: 2]])])],
       [
         """
         Sign up for our weekly newsletter to be notified of new episodes, and unlock access to any
@@ -485,7 +485,7 @@ private let signUpBlurb = View<(EpisodePermission, Episode)> { permission, episo
     a(
       [
         href(path(to: .login(redirect: path(to: .episode(.left(episode.slug)))))),
-        Styleguide.class([Class.pf.components.button(color: .black)])
+        `class`([Class.pf.components.button(color: .black)])
       ],
       ["Sign up for free episode"]
     )
@@ -507,17 +507,17 @@ private let subscribeView = View<(EpisodePermission, Database.User?, Episode)> {
       ],
       [
         h3(
-          [Styleguide.class([Class.pf.type.responsiveTitle4])],
+          [`class`([Class.pf.type.responsiveTitle4])],
           [.raw("Subscribe to Point&#8209;Free")]
         ),
 
         p(
-          [Styleguide.class([Class.pf.type.body.leading, Class.padding([.mobile: [.top: 2, .bottom: 3]])])],
+          [`class`([Class.pf.type.body.leading, Class.padding([.mobile: [.top: 2, .bottom: 3]])])],
           [.text(String(describing: subscribeBlurb(for: permission)))]
         ),
 
         a(
-          [href(path(to: .pricing(nil, expand: nil))), Styleguide.class([Class.pf.components.button(color: .purple)])],
+          [href(path(to: .pricing(nil, expand: nil))), `class`([Class.pf.components.button(color: .purple)])],
           ["See subscription options"]
         )
         ]
@@ -533,11 +533,11 @@ private let loginLink = View<(Database.User?, Episode)> { user, ep -> [Node] in
   guard user == nil else { return [] }
 
   return [
-    span([Styleguide.class([Class.padding([.mobile: [.left: 2]])])], ["or"]),
+    span([`class`([Class.padding([.mobile: [.left: 2]])])], ["or"]),
     a(
       [
         href(path(to: .login(redirect: url(to: .episode(.left(ep.slug)))))),
-        Styleguide.class([Class.pf.components.button(color: .black, style: .underline)])
+        `class`([Class.pf.components.button(color: .black, style: .underline)])
       ],
       ["Log in"]
     )
@@ -546,7 +546,7 @@ private let loginLink = View<(Database.User?, Episode)> { user, ep -> [Node] in
 
 private let episodeInfoView = View<(EpisodePermission, Episode)> { permission, ep in
   div(
-    [Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]]), Class.pf.colors.bg.white])],
+    [`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]]), Class.pf.colors.bg.white])],
     topLevelEpisodeInfoView.view(ep)
     + sectionsMenu(episode: ep, permission: permission)
   )
@@ -567,14 +567,14 @@ private func topLevelEpisodeMetadata(_ ep: Episode) -> String {
 let topLevelEpisodeInfoView = View<Episode> { ep in
   [
     strong(
-      [Styleguide.class([Class.pf.type.responsiveTitle8])],
+      [`class`([Class.pf.type.responsiveTitle8])],
       [.text(topLevelEpisodeMetadata(ep))]
     ),
     h1(
-      [Styleguide.class([Class.pf.type.responsiveTitle4, Class.margin([.mobile: [.top: 2]])])],
+      [`class`([Class.pf.type.responsiveTitle4, Class.margin([.mobile: [.top: 2]])])],
       [a([href(path(to: .episode(.left(ep.slug))))], [.text(ep.title)])]
     ),
-    div([Styleguide.class([Class.pf.type.body.leading])], [markdownBlock(ep.blurb)])
+    div([`class`([Class.pf.type.body.leading])], [markdownBlock(ep.blurb)])
     ]
 }
 
@@ -610,7 +610,7 @@ private func sectionsMenu(episode: Episode, permission: EpisodePermission?) -> [
   ]
 }
 
-let divider = hr([Styleguide.class([Class.pf.components.divider])])
+let divider = hr([`class`([Class.pf.components.divider])])
 let dividerView = View<Prelude.Unit>(const(divider))
 
 private let transcriptView = View<([Episode.TranscriptBlock], Bool)> { blocks, isEpisodeViewable in
@@ -678,7 +678,7 @@ private func subscriberCalloutView(isEpisodeViewable: Bool) -> [Node] {
                   a(
                     [
                       href(path(to: .pricing(nil, expand: nil))),
-                      Styleguide.class([Class.pf.type.underlineLink])
+                      `class`([Class.pf.type.underlineLink])
                     ],
                     ["subscribe"]
                   ),
@@ -710,7 +710,7 @@ private let referencesView = View<[Episode.Reference]> { references -> [Node] in
         h2(
           [
             id("references"),
-            Styleguide.class([Class.h4, Class.type.lineHeight(3), Class.padding([.mobile: [.top: 2]])])
+            `class`([Class.h4, Class.type.lineHeight(3), Class.padding([.mobile: [.top: 2]])])
           ],
           ["References"]
         ),
@@ -723,7 +723,7 @@ private let referencesView = View<[Episode.Reference]> { references -> [Node] in
               ],
               [
                 h4(
-                  [Styleguide.class([
+                  [`class`([
                     Class.pf.type.responsiveTitle5,
                     Class.margin([.mobile: [.bottom: 0]])
                     ])],
@@ -739,7 +739,7 @@ private let referencesView = View<[Episode.Reference]> { references -> [Node] in
                   ]
                 ),
                 strong(
-                  [Styleguide.class([Class.pf.type.body.small])],
+                  [`class`([Class.pf.type.body.small])],
                   [.text(topLevelReferenceMetadata(reference))]
                 ),
                 div([markdownBlock(reference.blurb ?? "")]),
@@ -807,7 +807,7 @@ private let exercisesView = View<[Episode.Exercise]> { exercises -> [Node] in
         h2(
           [
             id("exercises"),
-            Styleguide.class([Class.h4, Class.type.lineHeight(3), Class.padding([.mobile: [.top: 2]])])
+            `class`([Class.h4, Class.type.lineHeight(3), Class.padding([.mobile: [.top: 2]])])
           ],
           ["Exercises"]
         ),
@@ -829,7 +829,7 @@ let transcriptBlockView = View<Episode.TranscriptBlock> { block -> Node in
   case let .code(lang):
     return pre([
       code(
-        [Styleguide.class([Class.pf.components.code(lang: lang.identifier)])],
+        [`class`([Class.pf.components.code(lang: lang.identifier)])],
         [.text(block.content)]
       )
       ])
@@ -837,16 +837,16 @@ let transcriptBlockView = View<Episode.TranscriptBlock> { block -> Node in
   case .correction:
     return div(
       [
-        Styleguide.class([
+        `class`([
           Class.margin([.mobile: [.leftRight: 2, .topBottom: 3]]),
           Class.padding([.mobile: [.all: 2]]),
           ]),
         style("background-color: #ffdbdd;border-left: 3px solid #eb1c26;")
       ],
       [
-        h3([Styleguide.class([Class.pf.type.responsiveTitle6])], ["Correction"]),
+        h3([`class`([Class.pf.type.responsiveTitle6])], ["Correction"]),
         div(
-          [Styleguide.class([Class.pf.type.body.regular])],
+          [`class`([Class.pf.type.body.regular])],
           [markdownBlock(block.content)]
         ),
       ]
@@ -862,7 +862,7 @@ let transcriptBlockView = View<Episode.TranscriptBlock> { block -> Node in
 
     return a(
       [
-        Styleguide.class([outerImageContainerClass, Class.margin([.mobile: [.topBottom: 3]])]),
+        `class`([outerImageContainerClass, Class.margin([.mobile: [.topBottom: 3]])]),
         href(src),
         target(.blank),
         rel(.init(rawValue: "noopener noreferrer")),
@@ -879,7 +879,7 @@ let transcriptBlockView = View<Episode.TranscriptBlock> { block -> Node in
   case .title:
     return h2(
       [
-        Styleguide.class([Class.h4, Class.type.lineHeight(3), Class.padding([.mobile: [.top: 2]])]),
+        `class`([Class.h4, Class.type.lineHeight(3), Class.padding([.mobile: [.top: 2]])]),
         block.timestamp.map { id("t\($0)") }
         ]
         .compactMap(id),
@@ -893,13 +893,13 @@ let transcriptBlockView = View<Episode.TranscriptBlock> { block -> Node in
   case let .video(poster, sources):
     return div(
       [
-        Styleguide.class([outerVideoContainerClass, Class.margin([.mobile: [.topBottom: 2]])]),
+        `class`([outerVideoContainerClass, Class.margin([.mobile: [.topBottom: 2]])]),
         style(outerVideoContainerStyle)
       ],
       [
         video(
           [
-            Styleguide.class([innerVideoContainerClass]),
+            `class`([innerVideoContainerClass]),
             controls(true),
             playsinline(true),
             autoplay(false),
@@ -918,10 +918,10 @@ private let timestampLinkView = View<Int?> { timestamp -> [Node] in
   guard let timestamp = timestamp else { return [] }
 
   return [
-    div([id("t\(timestamp)"), Styleguide.class([Class.display.block])], [
+    div([id("t\(timestamp)"), `class`([Class.display.block])], [
       a(
         timestampLinkAttributes(timestamp: timestamp, useAnchors: false) + [
-          Styleguide.class([Class.pf.components.videoTimeLink])
+          `class`([Class.pf.components.videoTimeLink])
         ],
         [.text(timestampLabel(for: timestamp))])
       ])
@@ -940,12 +940,12 @@ private let episodeNotFoundView = simplePageLayout(_episodeNotFoundView)
 
 private let _episodeNotFoundView = View<(Either<String, Int>, Database.User?, SubscriberState, Route?)> { _, _, _, _ in
 
-  gridRow([Styleguide.class([Class.grid.center(.mobile)])], [
+  gridRow([`class`([Class.grid.center(.mobile)])], [
     gridColumn(sizes: [.mobile: 6], [
       div([style(padding(topBottom: .rem(12)))], [
-        h5([Styleguide.class([Class.h5])], ["Episode not found :("]),
+        h5([`class`([Class.h5])], ["Episode not found :("]),
         pre([
-          code([Styleguide.class([Class.pf.components.code(lang: "swift")])], [
+          code([`class`([Class.pf.components.code(lang: "swift")])], [
             "f: (Episode) -> Never"
             ])
           ])

--- a/Sources/PointFree/Footer.swift
+++ b/Sources/PointFree/Footer.swift
@@ -7,7 +7,7 @@ import Prelude
 import View
 
 let footerView: View<Database.User?> =
-  curry(footer)([Styleguide.class([footerClass])]) >>> pure
+  curry(footer)([`class`([footerClass])]) >>> pure
     <¢> footerInfoColumnsView
 
 private func column(sizes: [Breakpoint: Int]) -> ([Node]) -> [Node] {
@@ -30,33 +30,33 @@ private let linksColumnsView = View<Database.User?> { currentUser in
 }
 
 private let legalView = View<Prelude.Unit> { _ in
-  p([Styleguide.class([legalClass, Class.padding([.mobile: [.top: 2]])])], [
+  p([`class`([legalClass, Class.padding([.mobile: [.top: 2]])])], [
     .text("© \(year) Point-Free, Inc. All rights are reserved for the videos and transcripts on this site. "),
     "All other content is licensed under ",
-    a([Styleguide.class([Class.pf.colors.link.gray650]),
+    a([`class`([Class.pf.colors.link.gray650]),
        href("https://creativecommons.org/licenses/by-nc-sa/4.0/")],
       ["CC BY-NC-SA 4.0"]),
     ", and the underlying ",
-    a([Styleguide.class([Class.pf.colors.link.gray650]), href(gitHubUrl(to: .repo(.pointfreeco)))], ["source code"]),
+    a([`class`([Class.pf.colors.link.gray650]), href(gitHubUrl(to: .repo(.pointfreeco)))], ["source code"]),
     " to run this site is licensed under the ",
-    a([Styleguide.class([Class.pf.colors.link.gray650]), href(gitHubUrl(to: .license))], ["MIT license"])
+    a([`class`([Class.pf.colors.link.gray650]), href(gitHubUrl(to: .license))], ["MIT license"])
     ])
 }
 
 private let pointFreeView = View<Prelude.Unit> { _ -> Node in
-  div([Styleguide.class([Class.padding([.desktop: [.right: 4], .mobile: [.bottom: 2]])])], [
-    h4([Styleguide.class([Class.pf.type.responsiveTitle4, Class.margin([.mobile: [.bottom: 0]])])], [
-      a([href(path(to: .home)), Styleguide.class([Class.pf.colors.link.white])], ["Point-Free"])
+  div([`class`([Class.padding([.desktop: [.right: 4], .mobile: [.bottom: 2]])])], [
+    h4([`class`([Class.pf.type.responsiveTitle4, Class.margin([.mobile: [.bottom: 0]])])], [
+      a([href(path(to: .home)), `class`([Class.pf.colors.link.white])], ["Point-Free"])
       ]),
-    p([Styleguide.class([Class.pf.type.body.regular, Class.pf.colors.fg.white])], [
+    p([`class`([Class.pf.type.body.regular, Class.pf.colors.fg.white])], [
       "A video series on functional programming and the Swift programming language. Hosted by ",
       a(
-        [href(twitterUrl(to: .mbrandonw)), Styleguide.class([Class.type.textDecorationNone, Class.pf.colors.link.green])],
+        [href(twitterUrl(to: .mbrandonw)), `class`([Class.type.textDecorationNone, Class.pf.colors.link.green])],
         [.raw("Brandon&nbsp;Williams")]
       ),
       " and ",
       a(
-        [href(twitterUrl(to: .stephencelis)), Styleguide.class([Class.type.textDecorationNone, Class.pf.colors.link.green])],
+        [href(twitterUrl(to: .stephencelis)), `class`([Class.type.textDecorationNone, Class.pf.colors.link.green])],
         [.raw("Stephen&nbsp;Celis")]
       ),
       "."
@@ -67,18 +67,18 @@ private let pointFreeView = View<Prelude.Unit> { _ -> Node in
 private let contentColumnView = View<Database.User?> { currentUser -> Node in
 
   return div([
-    h5([Styleguide.class([columnTitleClass])], ["Content"]),
+    h5([`class`([columnTitleClass])], ["Content"]),
     ol(
-      [Styleguide.class([Class.type.list.reset])],
+      [`class`([Class.type.list.reset])],
       [
         li([
-          a([Styleguide.class([footerLinkClass]), href(path(to: .home))], ["Videos"])
+          a([`class`([footerLinkClass]), href(path(to: .home))], ["Videos"])
           ]),
         li([
-          a([Styleguide.class([footerLinkClass]), href(path(to: .blog(.index)))], ["Blog"])
+          a([`class`([footerLinkClass]), href(path(to: .blog(.index)))], ["Blog"])
           ]),
         li([
-          a([Styleguide.class([footerLinkClass]), href(path(to: .about))], ["About Us"])
+          a([`class`([footerLinkClass]), href(path(to: .about))], ["About Us"])
           ])
       ]
     )
@@ -87,13 +87,13 @@ private let contentColumnView = View<Database.User?> { currentUser -> Node in
 
 private let accountColumnView = View<Prelude.Unit> { _ in
   div([
-    h5([Styleguide.class([columnTitleClass])], ["Account"]),
-    ol([Styleguide.class([Class.type.list.reset])], [
+    h5([`class`([columnTitleClass])], ["Account"]),
+    ol([`class`([Class.type.list.reset])], [
       li([
-        a([Styleguide.class([footerLinkClass]), href(path(to: .pricing(nil, expand: nil)))], ["Subscribe"])
+        a([`class`([footerLinkClass]), href(path(to: .pricing(nil, expand: nil)))], ["Subscribe"])
         ]),
       li([
-        a([Styleguide.class([footerLinkClass]), href(path(to: .pricing(nil, expand: nil)))], ["Pricing"])
+        a([`class`([footerLinkClass]), href(path(to: .pricing(nil, expand: nil)))], ["Pricing"])
         ]),
       ])
     ])
@@ -101,19 +101,19 @@ private let accountColumnView = View<Prelude.Unit> { _ in
 
 private let moreColumnView = View<Prelude.Unit> { _ in
   div([
-    h5([Styleguide.class([columnTitleClass])], ["More"]),
-    ol([Styleguide.class([Class.type.list.reset])], [
+    h5([`class`([columnTitleClass])], ["More"]),
+    ol([`class`([Class.type.list.reset])], [
       li([
-        a([Styleguide.class([footerLinkClass]), href(twitterUrl(to: .pointfreeco))], ["Twitter"])
+        a([`class`([footerLinkClass]), href(twitterUrl(to: .pointfreeco))], ["Twitter"])
         ]),
       li([
-        a([Styleguide.class([footerLinkClass]), href(gitHubUrl(to: .organization))], ["GitHub"])
+        a([`class`([footerLinkClass]), href(gitHubUrl(to: .organization))], ["GitHub"])
         ]),
       li([
-        a([Styleguide.class([footerLinkClass]), mailto("support@pointfree.co")], ["Contact us"])
+        a([`class`([footerLinkClass]), mailto("support@pointfree.co")], ["Contact us"])
         ]),
       li([
-        a([Styleguide.class([footerLinkClass]), href(path(to: .privacy))], ["Privacy Policy"])
+        a([`class`([footerLinkClass]), href(path(to: .privacy))], ["Privacy Policy"])
         ]),
       ])
     ])

--- a/Sources/PointFree/Home.swift
+++ b/Sources/PointFree/Home.swift
@@ -86,7 +86,7 @@ private let subscriberCalloutView = View<SubscriberState> { subscriberState -> [
                   a(
                     [
                       href(path(to: .pricing(nil, expand: nil))),
-                      Styleguide.class([Class.pf.type.underlineLink])
+                      `class`([Class.pf.type.underlineLink])
                     ],
                     ["subscribing"]
                   ),
@@ -111,11 +111,11 @@ private let episodeRowView = View<Episode> { ep in
     gridRow([
       gridColumn(sizes: [.mobile: 12, .desktop: 7], episodeInfoColumnView.view(ep)),
 
-      gridColumn(sizes: [.mobile: 12, .desktop: 5], [Styleguide.class([Class.grid.first(.mobile), Class.grid.last(.desktop)])], [
-        div([Styleguide.class([Class.size.height100pct]), style(lineHeight(0) <> gradient <> minHeight(.px(300)))], [
+      gridColumn(sizes: [.mobile: 12, .desktop: 5], [`class`([Class.grid.first(.mobile), Class.grid.last(.desktop)])], [
+        div([`class`([Class.size.height100pct]), style(lineHeight(0) <> gradient <> minHeight(.px(300)))], [
           a([href(path(to: .episode(.left(ep.slug))))], [
             img(
-              [src(ep.image), alt(""), Styleguide.class([Class.size.width100pct, Class.size.height100pct]),
+              [src(ep.image), alt(""), `class`([Class.size.width100pct, Class.size.height100pct]),
                style(objectFit(.cover))]
             )
             ])
@@ -127,18 +127,18 @@ private let episodeRowView = View<Episode> { ep in
 
 private let episodeInfoColumnView = View<Episode> { ep in
   div(
-    [Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]]), Class.pf.colors.bg.white])],
+    [`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]]), Class.pf.colors.bg.white])],
     topLevelEpisodeInfoView.view(ep) + [
-      div([Styleguide.class([Class.margin([.mobile: [.top: 3]])])], [
+      div([`class`([Class.margin([.mobile: [.top: 3]])])], [
         a(
-          [href(path(to: .episode(.left(ep.slug)))), Styleguide.class([Class.align.middle, Class.pf.colors.link.purple, Class.pf.type.body.regular])],
+          [href(path(to: .episode(.left(ep.slug)))), `class`([Class.align.middle, Class.pf.colors.link.purple, Class.pf.type.body.regular])],
           [
             .text("Watch episode (\(ep.length / 60) min)"),
             img(
               base64: rightArrowSvgBase64(fill: "#974DFF"),
               type: .image(.svg),
               alt: "",
-              [Styleguide.class([Class.align.middle, Class.margin([.mobile: [.left: 1]])]), width(16), height(16)]
+              [`class`([Class.align.middle, Class.margin([.mobile: [.left: 1]])]), width(16), height(16)]
             )
           ]
         ),

--- a/Sources/PointFree/MinimalNavView.swift
+++ b/Sources/PointFree/MinimalNavView.swift
@@ -10,29 +10,29 @@ import Prelude
 import View
 
 let minimalNavView = View<(NavStyle.MinimalStyle, Database.User?, SubscriberState, Route?)> { style, currentUser, subscriberState, currentRoute in
-  gridRow([Styleguide.class([newNavBarClass(for: style)])], [
+  gridRow([`class`([newNavBarClass(for: style)])], [
     gridColumn(sizes: [:], [
-      div([Styleguide.class([Class.hide(.desktop)])], [
+      div([`class`([Class.hide(.desktop)])], [
         a([href(path(to: .home))], [
           img(
             base64: pointFreeDiamondLogoSvgBase64(fill: fillColor(for: style)),
             type: .image(.svg),
             alt: "",
-            [Styleguide.class([Class.hide(.desktop)])]
+            [`class`([Class.hide(.desktop)])]
           )
           ])
         ])
       ]),
 
     gridColumn(sizes: [:], [
-      div([Styleguide.class([Class.grid.center(.mobile)])], [
-        div([Styleguide.class([Class.hide(.mobile)])], [
+      div([`class`([Class.grid.center(.mobile)])], [
+        div([`class`([Class.hide(.mobile)])], [
           a([href(path(to: .home))], [
             img(
               base64: pointFreeTextLogoSvgBase64(color: fillColor(for: style)),
               type: .image(.svg),
               alt: "",
-              [Styleguide.class([Class.hide(.mobile)])]
+              [`class`([Class.hide(.mobile)])]
             )
             ])
           ])
@@ -67,9 +67,9 @@ private let loggedOutNavItemsView = navItems([
 
 private func navItems<A>(_ views: [View<A>]) -> View<A> {
   return View { a in
-    ul([Styleguide.class([navListClass])],
+    ul([`class`([navListClass])],
        views
-        .map { (curry(li)([Styleguide.class([navListItemClass])]) >>> pure) <¢> $0 }
+        .map { (curry(li)([`class`([navListItemClass])]) >>> pure) <¢> $0 }
         .concat()
         .view(a)
     )
@@ -77,15 +77,15 @@ private func navItems<A>(_ views: [View<A>]) -> View<A> {
 }
 
 private let blogLinkView = View<NavStyle.MinimalStyle> { style in
-  a([href(path(to: .blog(.index))), Styleguide.class([navLinkClass(for: style)])], ["Blog"])
+  a([href(path(to: .blog(.index))), `class`([navLinkClass(for: style)])], ["Blog"])
 }
 
 private let subscribeLinkView = View<NavStyle.MinimalStyle> { style in
-  a([href(path(to: .pricing(nil, expand: nil))), Styleguide.class([navLinkClass(for: style)])], ["Subscribe"])
+  a([href(path(to: .pricing(nil, expand: nil))), `class`([navLinkClass(for: style)])], ["Subscribe"])
 }
 
 private let accountLinkView = View<NavStyle.MinimalStyle> { style in
-  a([href(path(to: .account(.index))), Styleguide.class([navLinkClass(for: style)])], ["Account"])
+  a([href(path(to: .account(.index))), `class`([navLinkClass(for: style)])], ["Account"])
 }
 
 private let logInLinkView = View<(NavStyle.MinimalStyle, Route?)> { style, currentRoute in

--- a/Sources/PointFree/MountainNavView.swift
+++ b/Sources/PointFree/MountainNavView.swift
@@ -13,24 +13,24 @@ let mountainNavView = View<(NavStyle.MountainsStyle, Database.User?, SubscriberS
 
   menuAndLogoHeaderView.view((mountainsStyle, currentUser, subscriberState, currentRoute))
     + [
-      gridRow([Styleguide.class([Class.grid.top(.mobile), Class.grid.between(.mobile), Class.padding([.mobile: [.top: 3], .desktop: [.top: 0]])])], [
+      gridRow([`class`([Class.grid.top(.mobile), Class.grid.between(.mobile), Class.padding([.mobile: [.top: 3], .desktop: [.top: 0]])])], [
 
-        gridColumn(sizes: [.mobile: 5], [Styleguide.class([Class.padding([.mobile: [.top: 4], .desktop: [.top: 0]])]), style(lineHeight(0))], [
-          img(base64: heroMountainSvgBase64, type: .image(.svg), alt: "", [Styleguide.class([Class.size.width100pct])])
+        gridColumn(sizes: [.mobile: 5], [`class`([Class.padding([.mobile: [.top: 4], .desktop: [.top: 0]])]), style(lineHeight(0))], [
+          img(base64: heroMountainSvgBase64, type: .image(.svg), alt: "", [`class`([Class.size.width100pct])])
           ]),
 
-        gridColumn(sizes: [.mobile: 2], [Styleguide.class([Class.position.z1])], [
-          div([Styleguide.class([Class.type.align.center, Class.pf.type.body.leading]), style(margin(leftRight: .rem(-6)))], [
+        gridColumn(sizes: [.mobile: 2], [`class`([Class.position.z1])], [
+          div([`class`([Class.type.align.center, Class.pf.type.body.leading]), style(margin(leftRight: .rem(-6)))], [
             .text(mountainsStyle.heroTagline)
             ])
           ]),
 
-        gridColumn(sizes: [.mobile: 5], [Styleguide.class([Class.padding([.mobile: [.top: 4], .desktop: [.top: 0]])]), style(lineHeight(0))], [
+        gridColumn(sizes: [.mobile: 5], [`class`([Class.padding([.mobile: [.top: 4], .desktop: [.top: 0]])]), style(lineHeight(0))], [
           img(
             base64: heroMountainSvgBase64,
             type: .image(.svg),
             alt: "",
-            [Styleguide.class([Class.pf.components.reflectX, Class.size.width100pct])]
+            [`class`([Class.pf.components.reflectX, Class.size.width100pct])]
           )
           ]),
         ])
@@ -39,7 +39,7 @@ let mountainNavView = View<(NavStyle.MountainsStyle, Database.User?, SubscriberS
 
 private let menuAndLogoHeaderView = View<(NavStyle.MountainsStyle, Database.User?, SubscriberState, Route?)> { mountainsStyle, currentUser, subscriberState, currentRoute in
 
-  gridRow([Styleguide.class([Class.padding([.mobile: [.leftRight: 3, .top: 3, .bottom: 1], .desktop: [.leftRight: 4, .top: 4, .bottom: 4]]), Class.grid.top(.desktop), Class.grid.middle(.mobile), Class.grid.between(.mobile), Class.pf.components.blueGradient])], [
+  gridRow([`class`([Class.padding([.mobile: [.leftRight: 3, .top: 3, .bottom: 1], .desktop: [.leftRight: 4, .top: 4, .bottom: 4]]), Class.grid.top(.desktop), Class.grid.middle(.mobile), Class.grid.between(.mobile), Class.pf.components.blueGradient])], [
 
     gridColumn(sizes: [.mobile: 12], [
       gridRow([
@@ -49,20 +49,20 @@ private let menuAndLogoHeaderView = View<(NavStyle.MountainsStyle, Database.User
           ]),
         gridColumn(sizes: [.mobile: 12, .desktop: 6], [
           div(
-            [Styleguide.class([Class.grid.end(.mobile)])],
+            [`class`([Class.grid.end(.mobile)])],
             headerLinks.view((mountainsStyle, currentUser, subscriberState, currentRoute))
           )
           ])
         ]),
 
-      gridRow([Styleguide.class([Class.grid.center(.mobile), Class.padding([.mobile: [.topBottom: 2], .desktop: [.topBottom: 0]])])], [
+      gridRow([`class`([Class.grid.center(.mobile), Class.padding([.mobile: [.topBottom: 2], .desktop: [.topBottom: 0]])])], [
         gridColumn(sizes: [:], [
           a([href(path(to: .home))], [
             img(
               base64: mountainsStyle.heroLogoSvgBase64,
               type: .image(.svg),
               alt: "",
-              [Styleguide.class([Class.pf.components.heroLogo])]
+              [`class`([Class.pf.components.heroLogo])]
             )
             ])
           ])
@@ -75,17 +75,17 @@ private let headerLinks = View<(NavStyle.MountainsStyle, Database.User?, Subscri
 
   return [
     a(
-      [href(path(to: .blog(.index))), Styleguide.class([navLinkClasses])],
+      [href(path(to: .blog(.index))), `class`([navLinkClasses])],
       ["Blog"]
     ),
 
     subscriberState.isNonSubscriber
-      ? a([href(path(to: .pricing(nil, expand: nil))), Styleguide.class([navLinkClasses])], ["Subscribe"])
+      ? a([href(path(to: .pricing(nil, expand: nil))), `class`([navLinkClasses])], ["Subscribe"])
       : nil,
 
     currentUser == nil
       ? gitHubLink(text: "Login", type: .black, redirectRoute: currentRoute)
-      : a([href(path(to: .account(.index))), Styleguide.class([Class.type.medium, Class.pf.colors.link.black])], ["Account"]),
+      : a([href(path(to: .account(.index))), `class`([Class.type.medium, Class.pf.colors.link.black])], ["Account"]),
     ]
     .compactMap(id)
 }

--- a/Sources/PointFree/PageLayout.swift
+++ b/Sources/PointFree/PageLayout.swift
@@ -211,7 +211,7 @@ private func navView<A>(_ data: SimplePageLayoutData<A>) -> [Node] {
 }
 
 let flashView = View<Flash> { flash in
-  gridRow([Styleguide.class([flashClass(for: flash.priority)])], [
+  gridRow([`class`([flashClass(for: flash.priority)])], [
     gridColumn(sizes: [.mobile: 12], [markdownBlock(flash.message)])
     ])
 }

--- a/Sources/PointFree/Pricing.swift
+++ b/Sources/PointFree/Pricing.swift
@@ -164,16 +164,16 @@ public enum PricingFormStyle {
 
 let pricingOptionsView = View<(Database.User?, Pricing, PricingFormStyle, Stripe.Coupon?, Route?)> { currentUser, pricing, formStyle, coupon, route in
 
-  gridRow([Styleguide.class([pricingOptionsRowClass])], [
+  gridRow([`class`([pricingOptionsRowClass])], [
     gridColumn(sizes: [.mobile: 12, .desktop: 7], [], [
       div([
         h2(
-          [Styleguide.class([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle2])],
+          [`class`([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle2])],
           [.raw("Subscribe to Point&#8209;Free")]
         ),
 
         p(
-          [Styleguide.class([Class.pf.colors.fg.green])],
+          [`class`([Class.pf.colors.fg.green])],
           [
             """
             Become a subscriber to unlock every full episode and explore new functional programming concepts
@@ -182,7 +182,7 @@ let pricingOptionsView = View<(Database.User?, Pricing, PricingFormStyle, Stripe
           ]
         ),
 
-        gridRow([Styleguide.class([Class.padding([.mobile: [.bottom: 3]]), Class.margin([.mobile: [.top: 4]])])], [
+        gridRow([`class`([Class.padding([.mobile: [.bottom: 3]]), Class.margin([.mobile: [.top: 4]])])], [
           gridColumn(sizes: [.mobile: 12], [], [
             form(
               [
@@ -192,7 +192,7 @@ let pricingOptionsView = View<(Database.User?, Pricing, PricingFormStyle, Stripe
                 onsubmit("event.preventDefault()")
               ],
               pricingTabsView.view(pricing)
-                <> [div([Styleguide.class([Class.margin([.mobile: [.bottom: 3]])])], [])]
+                <> [div([`class`([Class.margin([.mobile: [.bottom: 3]])])], [])]
                 <> quantityRowView.view(pricing)
                 <> pricingIntervalRowView.view((pricing, coupon))
                 <> pricingFooterView.view((currentUser, formStyle, coupon?.id, route))
@@ -220,12 +220,12 @@ private let whatToExpectStyles =
 private let whatToExpect = View<Prelude.Unit> { _ in
   [
     h4(
-      [Styleguide.class([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4])],
+      [`class`([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4])],
       [.raw("What to expect?")]
     ),
 
     p(
-      [Styleguide.class([Class.pf.colors.fg.white])],
+      [`class`([Class.pf.colors.fg.white])],
       [
         """
         Quality video content dissecting some of the most important topics in functional programming. Each
@@ -240,12 +240,12 @@ private let whatToExpect = View<Prelude.Unit> { _ in
 private let topicsView = View<Prelude.Unit> { _ in
   [
     h4(
-      [Styleguide.class([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
+      [`class`([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
       [.raw("What kind of topics will you cover?")]
     ),
 
     p(
-      [Styleguide.class([Class.pf.colors.fg.white])],
+      [`class`([Class.pf.colors.fg.white])],
       [
         """
         We will of course cover all of the classic topics such as functors, monads and applicatives (oh
@@ -256,7 +256,7 @@ private let topicsView = View<Prelude.Unit> { _ in
     ),
 
     ul(
-      [Styleguide.class([Class.pf.colors.fg.green, Class.type.align.start])], [
+      [`class`([Class.pf.colors.fg.green, Class.type.align.start])], [
         li(["Pure functions and side effects"]),
         li(["Code reuse through function composition"]),
         li(["Maximizing use of the type-system"]),
@@ -268,12 +268,12 @@ private let topicsView = View<Prelude.Unit> { _ in
 private let suggestATopic = View<Prelude.Unit> { _ in
   [
     h4(
-      [Styleguide.class([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
+      [`class`([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
       [.raw("Can I suggest a topic?")]
     ),
 
     p(
-      [Styleguide.class([Class.pf.colors.fg.white])],
+      [`class`([Class.pf.colors.fg.white])],
       [
         "Sure thing! Send us an ",
         a(
@@ -289,12 +289,12 @@ private let suggestATopic = View<Prelude.Unit> { _ in
 private let studentDiscounts = View<Prelude.Unit> { _ in
   [
     h4(
-      [Styleguide.class([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
+      [`class`([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
       [.text("Do you offer student discounts?")]
     ),
 
     p(
-      [Styleguide.class([Class.pf.colors.fg.white])],
+      [`class`([Class.pf.colors.fg.white])],
       [
         "We do! If you ",
         a([mailto("support@pointfree.co?subject=Student%20Discount"), style(faqLinkStyles)], ["email us"]),
@@ -308,12 +308,12 @@ private let studentDiscounts = View<Prelude.Unit> { _ in
 private let whoAreYou = View<Prelude.Unit> { _ in
   [
     h4(
-      [Styleguide.class([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
+      [`class`([Class.pf.colors.fg.white, Class.pf.type.responsiveTitle4, Class.padding([.mobile: [.top: 2]])])],
       [.raw("Who are you?")]
     ),
 
     p(
-      [Styleguide.class([Class.pf.colors.fg.white])],
+      [`class`([Class.pf.colors.fg.white])],
       [
         "We’re ",
         a([href("http://www.fewbutripe.com"), style(faqLinkStyles)], ["Brandon Williams"]),
@@ -325,7 +325,7 @@ private let whoAreYou = View<Prelude.Unit> { _ in
     ),
 
     ul(
-      [Styleguide.class([Class.pf.colors.fg.blue, Class.type.align.start])], [
+      [`class`([Class.pf.colors.fg.blue, Class.type.align.start])], [
         li([
           a([href("http://www.fewbutripe.com/talks/"), style(faqLinkStyles)],
             ["Brandon’s talks"])
@@ -340,9 +340,9 @@ private let whoAreYou = View<Prelude.Unit> { _ in
 }
 
 private let faqView = View<Prelude.Unit> { _ in
-  gridRow([Styleguide.class([pricingOptionsRowClass])], [
+  gridRow([`class`([pricingOptionsRowClass])], [
     gridColumn(sizes: [.mobile: 12, .desktop: 7], [], [
-      div([Styleguide.class([whatToExpectBoxClass])],
+      div([`class`([whatToExpectBoxClass])],
           whatToExpect.view(unit)
             <> topicsView.view(unit)
             <> studentDiscounts.view(unit)
@@ -361,29 +361,29 @@ private let pricingTabsView = View<Pricing> { pricing in
   [
     input([
       checked(pricing.isIndividual),
-      Styleguide.class([Class.display.none]),
+      `class`([Class.display.none]),
       id(selectors.input.0),
       name("pricing[lane]"),
       type(.radio),
       value("individual"),
       role(.button)
       ]),
-    label([`for`(selectors.input.0), Styleguide.class([Class.pf.components.pricingTab]), style(extraTabStyles)], [
+    label([`for`(selectors.input.0), `class`([Class.pf.components.pricingTab]), style(extraTabStyles)], [
       "For you"
       ]),
 
-    span([Styleguide.class([Class.padding([.mobile: [.leftRight: 2]]), Class.pf.colors.fg.gray850])], ["or"]),
+    span([`class`([Class.padding([.mobile: [.leftRight: 2]]), Class.pf.colors.fg.gray850])], ["or"]),
 
     input([
       checked(pricing.isTeam),
-      Styleguide.class([Class.display.none]),
+      `class`([Class.display.none]),
       id(selectors.input.1),
       name("pricing[lane]"),
       type(.radio),
       value("team"),
       role(.button)
       ]),
-    label([`for`(selectors.input.1), Styleguide.class([Class.pf.components.pricingTab]), style(extraTabStyles)], [
+    label([`for`(selectors.input.1), `class`([Class.pf.components.pricingTab]), style(extraTabStyles)], [
       "For your team"
       ])
   ]
@@ -391,18 +391,18 @@ private let pricingTabsView = View<Pricing> { pricing in
 
 private let pricingIntervalRowView = View<(Pricing, Stripe.Coupon?)> { pricing, coupon in
   gridRow(
-    [Styleguide.class([Class.pf.colors.bg.white])],
+    [`class`([Class.pf.colors.bg.white])],
     individualPricingColumnView.view((.monthly, pricing, coupon))
       <> individualPricingColumnView.view((.yearly, pricing, coupon))
       <> [
         gridColumn(
-          sizes: [.mobile: 12], [Styleguide.class([Class.pf.colors.bg.white])],
+          sizes: [.mobile: 12], [`class`([Class.pf.colors.bg.white])],
           (
             coupon
               .map {
                 [
                   p([
-                    Styleguide.class([
+                    `class`([
                       selectors.content.0,
                       Class.padding([.mobile: [.bottom: 1]]),
                       Class.pf.colors.fg.gray400,
@@ -419,7 +419,7 @@ private let pricingIntervalRowView = View<(Pricing, Stripe.Coupon?)> { pricing, 
             )
             <> [
               p([
-                Styleguide.class([
+                `class`([
                   selectors.content.1,
                   Class.padding([.mobile: [.bottom: 1]]),
                   Class.pf.colors.fg.gray400,
@@ -442,8 +442,8 @@ func isChecked(_ billing: Pricing.Billing, _ pricing: Pricing) -> Bool {
 let teamPriceClass = CssSelector.class("team-price")
 
 private let individualPricingColumnView = View<(Pricing.Billing, Pricing, Stripe.Coupon?)> { billing, pricing, coupon -> Node in
-  return gridColumn(sizes: [.mobile: 6], [Styleguide.class([Class.pf.colors.bg.white])], [
-    label([`for`(billing.rawValue), Styleguide.class([Class.display.block, Class.margin([.mobile: [.all: 3]])])], [
+  return gridColumn(sizes: [.mobile: 6], [`class`([Class.pf.colors.bg.white])], [
+    label([`for`(billing.rawValue), `class`([Class.display.block, Class.margin([.mobile: [.all: 3]])])], [
       gridRow([style(flex(direction: .columnReverse))], [
         input([
           checked(isChecked(billing, pricing)),
@@ -453,14 +453,14 @@ private let individualPricingColumnView = View<(Pricing.Billing, Pricing, Stripe
           value(billing.rawValue),
           ]),
         gridColumn(sizes: [.mobile: 12], [], [
-          h2([Styleguide.class([Class.pf.type.responsiveTitle2, Class.type.light, Class.pf.colors.fg.gray650])], [
-            span([Styleguide.class([selectors.content.0])], [
+          h2([`class`([Class.pf.type.responsiveTitle2, Class.type.light, Class.pf.colors.fg.gray650])], [
+            span([`class`([selectors.content.0])], [
               .text(individualPricingText(for: billing, coupon: coupon)),
               ]),
-            span([Styleguide.class([selectors.content.1])], [
+            span([`class`([selectors.content.1])], [
               "$",
               span(
-                [Styleguide.class([teamPriceClass]), data("price", String(defaultTeamPricing(for: billing)))],
+                [`class`([teamPriceClass]), data("price", String(defaultTeamPricing(for: billing)))],
                 [.text(String(defaultTeamPricing(for: billing) * clamp(Pricing.validTeamQuantities)(pricing.quantity)))]
               ),
               "/",
@@ -469,7 +469,7 @@ private let individualPricingColumnView = View<(Pricing.Billing, Pricing, Stripe
             ]),
           ]),
         gridColumn(sizes: [.mobile: 12], [], [
-          h6([Styleguide.class([Class.pf.type.responsiveTitle7, Class.pf.colors.fg.gray650, Class.display.inline])], [
+          h6([`class`([Class.pf.type.responsiveTitle7, Class.pf.colors.fg.gray650, Class.display.inline])], [
             .text(title(for: billing))
             ]),
           ]),
@@ -482,15 +482,15 @@ private let quantityRowView = View<Pricing> { pricing -> Node in
 
   let quantity = clamp(Pricing.validTeamQuantities) <| pricing.quantity
 
-  return div([Styleguide.class([Class.flex.flex])], [
-    gridRow([Styleguide.class([selectors.content.1, Class.pf.colors.bg.white, Class.size.width100pct])], [
+  return div([`class`([Class.flex.flex])], [
+    gridRow([`class`([selectors.content.1, Class.pf.colors.bg.white, Class.size.width100pct])], [
       gridColumn(sizes: [.mobile: 12], [], [
-        div([Styleguide.class([Class.padding([.mobile: [.top: 3, .left: 3, .right: 3]])])], [
+        div([`class`([Class.padding([.mobile: [.top: 3, .left: 3, .right: 3]])])], [
 
-          p([Styleguide.class([Class.pf.colors.fg.black, Class.pf.type.body.regular])], ["How many in your team?"]),
+          p([`class`([Class.pf.colors.fg.black, Class.pf.type.body.regular])], ["How many in your team?"]),
 
           input([
-            Styleguide.class([numberSpinner, Class.pf.colors.fg.black]),
+            `class`([numberSpinner, Class.pf.colors.fg.black]),
             max(Pricing.validTeamQuantities.upperBound),
             min(Pricing.validTeamQuantities.lowerBound),
             name("pricing[quantity]"),
@@ -533,7 +533,7 @@ private let quantityRowView = View<Pricing> { pricing -> Node in
             ]),
 
           hr([
-            Styleguide.class([
+            `class`([
               Class.pf.components.divider,
               Class.margin([.mobile: [.top: 3]])
               ]),
@@ -563,10 +563,10 @@ let extraSpinnerStyles =
     <> (input & .elem(.other("::-webkit-outer-spin-button"))) % opacity(1)
 
 private let pricingFooterView = View<(Database.User?, PricingFormStyle, Stripe.Coupon.Id?, Route?)> { currentUser, formStyle, couponId, route in
-  gridRow([Styleguide.class([Class.pf.colors.bg.white])], [
+  gridRow([`class`([Class.pf.colors.bg.white])], [
     gridColumn(sizes: [.mobile: 12], [], [
       div(
-        [Styleguide.class([Class.padding([.mobile: [.top: 2, .bottom: 3]])])],
+        [`class`([Class.padding([.mobile: [.top: 2, .bottom: 3]])])],
         currentUser
           .map(const(stripeForm.view((couponId, formStyle))))
           ?? (
@@ -585,13 +585,13 @@ private let pricingFooterView = View<(Database.User?, PricingFormStyle, Stripe.C
 
 private let stripeForm = View<(Stripe.Coupon.Id?, PricingFormStyle)> { couponId, formStyle in
   div(
-    [Styleguide.class([Class.padding([.mobile: [.left: 3, .right: 3]])])],
+    [`class`([Class.padding([.mobile: [.left: 3, .right: 3]])])],
     Stripe.html.cardInput(couponId: couponId, formStyle: formStyle)
       <> Stripe.html.errors
       <> Stripe.html.scripts
       <> [
         button(
-          [Styleguide.class([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])])],
+          [`class`([Class.pf.components.button(color: .purple), Class.margin([.mobile: [.top: 3]])])],
           ["Subscribe to Point", .raw("&#8209;"), "Free"]
         )
     ]
@@ -602,11 +602,11 @@ private let loggedOutStripeForm = View<Stripe.Coupon.Id?> { couponId -> [Node] i
   guard let couponId = couponId else { return [] }
   return [
     div(
-      [Styleguide.class([Class.padding([.mobile: [.left: 3, .right: 3, .bottom: 2]])])],
+      [`class`([Class.padding([.mobile: [.left: 3, .right: 3, .bottom: 2]])])],
       [
         div([
           input([
-            Styleguide.class([blockInputClass]),
+            `class`([blockInputClass]),
             disabled(true),
             name("coupon"),
             placeholder("Coupon Code"),

--- a/Sources/PointFree/Privacy.swift
+++ b/Sources/PointFree/Privacy.swift
@@ -33,12 +33,12 @@ private let privacyView = View<Prelude.Unit> { _ in
   gridRow([
     gridColumn(sizes: [.mobile: 12, .desktop: 8], [style(margin(leftRight: .auto))], [
       div(
-        [Styleguide.class([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
-        [h1([Styleguide.class([Class.pf.type.responsiveTitle2])], [.text(title)])]
+        [`class`([Class.padding([.mobile: [.all: 3], .desktop: [.all: 4]])])],
+        [h1([`class`([Class.pf.type.responsiveTitle2])], [.text(title)])]
           <> privacyPolicy
           <> [
             p(
-              [Styleguide.class([Class.padding([.mobile: [.top: 2]])])],
+              [`class`([Class.padding([.mobile: [.top: 2]])])],
               ["This document was last updated on January 7, 2018."]
             )
         ]
@@ -60,7 +60,7 @@ private let privacyPolicy =
 
 private let personalIdentificationInformation = [
   h2(
-    [Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
+    [`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
     ["Personal identification information"]),
   p([
     """
@@ -72,7 +72,7 @@ private let personalIdentificationInformation = [
 
 private let nonPersonalIdentificationInformation = [
   h2(
-    [Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
+    [`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
     ["Non-personal identification information"]),
   p([
     """
@@ -84,7 +84,7 @@ private let nonPersonalIdentificationInformation = [
 
 private let webBrowserCookies = [
   h2(
-    [Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
+    [`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
     ["Web browser cookies"]),
   p([
     """
@@ -96,7 +96,7 @@ private let webBrowserCookies = [
 
 private let howWeUseCollectedInformation = [
   h2(
-    [Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
+    [`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
     ["How we use collected information"]),
   p([
     """
@@ -126,7 +126,7 @@ private let howWeUseCollectedInformation = [
 
 private let howWeProtectYourInformation = [
   h2(
-    [Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
+    [`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
     ["How we protect your information"]),
   p([
     """
@@ -143,7 +143,7 @@ private let howWeProtectYourInformation = [
 
 private let sharingYourPersonalInformation = [
   h2(
-    [Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
+    [`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])],
     ["Sharing your personal information"]),
   p([
     """
@@ -155,7 +155,7 @@ private let sharingYourPersonalInformation = [
 ]
 
 private let complianceWithChildrensOnlinePrivacyProtectionAct = [
-  h2([Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])], ["Compliance with children's online privacy protection act"]),
+  h2([`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])], ["Compliance with children's online privacy protection act"]),
   p([
     """
     Protecting the privacy of the very young is especially important. For that reason, we never collect
@@ -165,7 +165,7 @@ private let complianceWithChildrensOnlinePrivacyProtectionAct = [
 ]
 
 private let changesToThisPrivacyPolicy = [
-  h2([Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])], ["Changes to this privacy policy"]),
+  h2([`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])], ["Changes to this privacy policy"]),
   p([
     """
     Point-Free, Inc. has the discretion to update this privacy policy at any time. When we do, we will
@@ -174,7 +174,7 @@ private let changesToThisPrivacyPolicy = [
 ]
 
 private let contactingUs = [
-  h2([Styleguide.class([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])], ["Contacting us"]),
+  h2([`class`([Class.pf.type.responsiveTitle3, Class.padding([.mobile: [.top: 2]])])], ["Contacting us"]),
   p([
     "Questions about this policy can be sent to ",
     a([mailto("support@pointfree.co")], ["support@pointfree.co"]),

--- a/Sources/PointFree/PublicEpisodes/0022-ATourOfPointFreeCo.swift
+++ b/Sources/PointFree/PublicEpisodes/0022-ATourOfPointFreeCo.swift
@@ -1439,7 +1439,7 @@ I can hop over to our footer view and locate the contact link.
   ),
   Episode.TranscriptBlock(
     content: """
-a([Styleguide.class([footerLinkClass]), mailto("support@pointfree.co")], ["Contact us"])
+a([`class`([footerLinkClass]), mailto("support@pointfree.co")], ["Contact us"])
 """,
     timestamp: nil,
     type: .code(lang: .swift)
@@ -1453,7 +1453,7 @@ And I can update it to say "Support" and provide an `href`. I could just hard-co
   ),
   Episode.TranscriptBlock(
     content: """
-a([Styleguide.class([footerLinkClass]), href("/support")], ["Support"])
+a([`class`([footerLinkClass]), href("/support")], ["Support"])
 """,
     timestamp: nil,
     type: .code(lang: .swift)
@@ -1481,7 +1481,7 @@ We want to use our router and we have a little helper here that just calls out t
   ),
   Episode.TranscriptBlock(
     content: """
-a([Styleguide.class([footerLinkClass]), href(path(to: .support))], ["Support"])
+a([`class`([footerLinkClass]), href(path(to: .support))], ["Support"])
 """,
     timestamp: nil,
     type: .code(lang: .swift)

--- a/Sources/PointFree/RouteNotFoundMiddleware.swift
+++ b/Sources/PointFree/RouteNotFoundMiddleware.swift
@@ -26,12 +26,12 @@ let routeNotFoundMiddleware =
 )
 
 private let routeNotFoundView = View<Prelude.Unit> { _ in
-  gridRow([Styleguide.class([Class.grid.center(.mobile)])], [
+  gridRow([`class`([Class.grid.center(.mobile)])], [
     gridColumn(sizes: [.mobile: 6], [
       div([style(padding(topBottom: .rem(12)))], [
-        h5([Styleguide.class([Class.pf.type.responsiveTitle5])], ["Page not found :("]),
+        h5([`class`([Class.pf.type.responsiveTitle5])], ["Page not found :("]),
         pre([
-          code([Styleguide.class([Class.pf.components.code(lang: "swift")])], [
+          code([`class`([Class.pf.components.code(lang: "swift")])], [
             "f: (Page) -> Never"
             ])
           ])

--- a/Sources/PointFree/StripeHtml.swift
+++ b/Sources/PointFree/StripeHtml.swift
@@ -13,22 +13,22 @@ extension Stripe {
         input([name("token"), type(.hidden)]),
         div([`class`(expand ? [] : [Class.display.none])], [
           input([
-            Styleguide.class([blockInputClass]),
+            `class`([blockInputClass]),
             name("stripe_name"),
             placeholder("Billing Name"),
             type(.text),
             ]),
           input([
-            Styleguide.class([blockInputClass]),
+            `class`([blockInputClass]),
             name("stripe_address_line1"),
             placeholder("Address"),
             type(.text),
             ]),
           gridRow([
             gridColumn(sizes: [.mobile: 12, .desktop: 4], [
-              div([Styleguide.class([Class.padding([.desktop: [.right: 1]])])], [
+              div([`class`([Class.padding([.desktop: [.right: 1]])])], [
                 input([
-                  Styleguide.class([blockInputClass]),
+                  `class`([blockInputClass]),
                   name("stripe_address_city"),
                   placeholder("City"),
                   type(.text),
@@ -36,9 +36,9 @@ extension Stripe {
                 ])
               ]),
             gridColumn(sizes: [.mobile: 12, .desktop: 3], [
-              div([Styleguide.class([Class.padding([.desktop: [.leftRight: 1]])])], [
+              div([`class`([Class.padding([.desktop: [.leftRight: 1]])])], [
                 input([
-                  Styleguide.class([blockInputClass]),
+                  `class`([blockInputClass]),
                   name("stripe_address_state"),
                   placeholder("State"),
                   type(.text),
@@ -46,9 +46,9 @@ extension Stripe {
                 ])
               ]),
             gridColumn(sizes: [.mobile: 12, .desktop: 2], [
-              div([Styleguide.class([Class.padding([.desktop: [.leftRight: 1]])])], [
+              div([`class`([Class.padding([.desktop: [.leftRight: 1]])])], [
                 input([
-                  Styleguide.class([blockInputClass]),
+                  `class`([blockInputClass]),
                   name("stripe_address_zip"),
                   placeholder("Zip"),
                   type(.text),
@@ -56,8 +56,8 @@ extension Stripe {
                 ])
               ]),
             gridColumn(sizes: [.mobile: 12, .desktop: 3], [
-              div([Styleguide.class([Class.padding([.desktop: [.left: 1]])])], [
-                select([Styleguide.class([blockSelectClass]), name("stripe_address_country")], [option([disabled(true), selected(true), value("")], "Country")] + countries.map { pair in
+              div([`class`([Class.padding([.desktop: [.left: 1]])])], [
+                select([`class`([blockSelectClass]), name("stripe_address_country")], [option([disabled(true), selected(true), value("")], "Country")] + countries.map { pair in
                   let (country, code) = pair
                   return option([value(code)], country)
                 })
@@ -65,7 +65,7 @@ extension Stripe {
               ]),
             ]),
           input([
-            Styleguide.class([blockInputClass]),
+            `class`([blockInputClass]),
             name("vatNumber"),
             placeholder("VAT Number (EU Customers Only)"),
             type(.text),
@@ -73,7 +73,7 @@ extension Stripe {
           ]),
         div([`class`(couponId != nil ? [] : [Class.display.none])], [
           input([
-            Styleguide.class([blockInputClass]),
+            `class`([blockInputClass]),
             name("coupon"),
             placeholder("Coupon Code"),
             type(.text),
@@ -82,7 +82,7 @@ extension Stripe {
           ]),
         div(
           [
-            Styleguide.class([stripeInputClass]),
+            `class`([stripeInputClass]),
             data("stripe-key", Current.envVars.stripe.publishableKey),
             id("card-element"),
           ],
@@ -94,7 +94,7 @@ extension Stripe {
     public static let errors = [
       div(
         [
-          Styleguide.class([Class.pf.colors.fg.red]),
+          `class`([Class.pf.colors.fg.red]),
           id("card-errors"),
           role(.alert),
         ],

--- a/Sources/PointFree/StripeWebhooks.swift
+++ b/Sources/PointFree/StripeWebhooks.swift
@@ -147,22 +147,22 @@ private let pastDueEmailBodyView = View<Prelude.Unit> { _ in
   emailTable([style(contentTableStyles)], [
     tr([
       td([valign(.top)], [
-        div([Styleguide.class([Class.padding([.mobile: [.all: 2]])])], [
-          h3([Styleguide.class([Class.pf.type.responsiveTitle3])], ["Payment failed"]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+        div([`class`([Class.padding([.mobile: [.all: 2]])])], [
+          h3([`class`([Class.pf.type.responsiveTitle3])], ["Payment failed"]),
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             """
             Your most recent subscription payment was declined. This could be due to a change in your card
             number, your card expiring, cancellation of your credit card, or the card issuer not recognizing
             the payment and therefore taking action to prevent it.
             """
             ]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
             """
             Please update your payment info to ensure uninterrupted access to Point-Free!
             """
             ]),
-          p([Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])], [
-            a([href(url(to: .account(.paymentInfo(.show(expand: nil))))), Styleguide.class([Class.pf.components.button(color: .purple)])],
+          p([`class`([Class.padding([.mobile: [.topBottom: 2]])])], [
+            a([href(url(to: .account(.paymentInfo(.show(expand: nil))))), `class`([Class.pf.components.button(color: .purple)])],
               ["Update payment info"])
             ])
           ])

--- a/Sources/PointFree/Tag.swift
+++ b/Sources/PointFree/Tag.swift
@@ -33,12 +33,12 @@ extension SiteTag {
 
 public let pillTagsView = View<[SiteTag]> { tags in
   ol(
-    [Styleguide.class([Class.display.inlineBlock, Class.type.list.reset])],
+    [`class`([Class.display.inlineBlock, Class.type.list.reset])],
     tags
       .sorted(by: their(^\.name))
       .map(
         episodeTagView.view
-          >>> curry(li)([Styleguide.class([Class.display.inlineBlock, Class.margin([.mobile: [.right: 1, .bottom: 1]])])])
+          >>> curry(li)([`class`([Class.display.inlineBlock, Class.margin([.mobile: [.right: 1, .bottom: 1]])])])
     )
   )
 }
@@ -47,7 +47,7 @@ private let episodeTagView = View<SiteTag> { tag in
   a(
     [
       href("#"),
-      Styleguide.class([
+      `class`([
         Class.h6,
         Class.padding([.mobile: [.leftRight: 2, .topBottom: 1]]),
         Class.border.pill,

--- a/Sources/PointFree/Tasks.swift
+++ b/Sources/PointFree/Tasks.swift
@@ -93,7 +93,7 @@ private let wrapper = { view in
     emailTable([style(contentTableStyles)], [
       tr([
         td([valign(.top)], [
-          div([Styleguide.class([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])], view)
+          div([`class`([Class.padding([.mobile: [.all: 0], .desktop: [.all: 2]])])], view)
           ])
         ])
       ])
@@ -271,9 +271,9 @@ let welcomeEmail3Content = View<Database.User> { user -> [Node] in
 }
 
 private let subscribeButton = p(
-  [Styleguide.class([Class.padding([.mobile: [.topBottom: 2]])])],
+  [`class`([Class.padding([.mobile: [.topBottom: 2]])])],
   [
-    a([href(url(to: .pricing(nil, expand: nil))), Styleguide.class([Class.pf.components.button(color: .purple)])],
+    a([href(url(to: .pricing(nil, expand: nil))), `class`([Class.pf.components.button(color: .purple)])],
       ["Subscribe to Point-Free!"]
     ),
   ]


### PR DESCRIPTION
We have a bunch of `Styleguide.` and `Html.` qualifications that are not necessary. I think we added these while updating to swift-html and the compiler was just pointing to all types of lines as being problematic when they really weren't.