### PR TITLE
Drop timeout for now.

### DIFF
--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -9,7 +9,6 @@ import Tuple
 
 public let siteMiddleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
   requestLogger { Current.logger.info($0) }
-    <<< responseTimeout(25)
     <<< requireHerokuHttps(allowedInsecureHosts: allowedInsecureHosts)
     <<< redirectUnrelatedHosts(isAllowedHost: { isAllowed(host: $0) }, canonicalHost: canonicalHost)
     <<< route(router: router, notFound: routeNotFoundMiddleware)


### PR DESCRIPTION
Now that we have a proper timeout in the API climate let's drop this timeout until we have a better way to cleanup resources.