### PR TITLE
Another way of doing tagged values in routes.

### DIFF
--- a/Sources/PointFreeRouter/AccountRoutes.swift
+++ b/Sources/PointFreeRouter/AccountRoutes.swift
@@ -43,7 +43,7 @@ private func accountRouters(appSecret: String) -> [Router<Account>] {
   return [
     .confirmEmailChange
       <¢> get %> lit("confirm-email-change")
-      %> queryParam("payload", .decrypted(withSecret: appSecret) >>> payload(.uuid >>> .tagged, .tagged))
+      %> queryParam("payload", .decrypted(withSecret: appSecret) >>> payload(.tagged(.uuid), .tagged))
       <% end,
 
     .index
@@ -53,7 +53,7 @@ private func accountRouters(appSecret: String) -> [Router<Account>] {
       <¢> get %> lit("invoices") <% end,
 
     .invoices <<< .show
-      <¢> get %> lit("invoices") %> pathParam(.string >>> .tagged) <% end,
+      <¢> get %> lit("invoices") %> pathParam(.tagged(.string)) <% end,
 
     .paymentInfo <<< .show
       <¢> get %> lit("payment-info")
@@ -62,13 +62,13 @@ private func accountRouters(appSecret: String) -> [Router<Account>] {
 
     .paymentInfo <<< .update
       <¢> post %> lit("payment-info")
-      %> formField("token", Optional.iso.some >>> opt(.string >>> .tagged))
+      %> formField("token", Optional.iso.some >>> opt(.tagged(.string)))
       <% end,
 
     .rss
       <¢> (get <|> head) %> lit("rss")
-      %> pathParam(.decrypted(withSecret: appSecret) >>> .uuid >>> .tagged)
-      <%> pathParam(.decrypted(withSecret: appSecret) >>> .uuid >>> .tagged)
+      %> pathParam(.decrypted(withSecret: appSecret) >>> .tagged(.uuid))
+      <%> pathParam(.decrypted(withSecret: appSecret) >>> .tagged(.uuid))
       <% end,
 
     .subscription <<< .cancel

--- a/Sources/PointFreeRouter/AdminRoutes.swift
+++ b/Sources/PointFreeRouter/AdminRoutes.swift
@@ -35,7 +35,7 @@ public let adminRouter = routers.reduce(.empty, <|>)
 private let routers: [Router<Admin>] = [
   .episodeCredits <<< .add
     <¢> post %> lit("episode-credits") %> lit("add")
-    %> formField("user_id", Optional.iso.some >>> opt(.uuid >>> .tagged))
+    %> formField("user_id", Optional.iso.some >>> opt(.tagged(.uuid)))
     <%> formField("episode_sequence", Optional.iso.some >>> opt(.int))
     <% end,
 
@@ -46,7 +46,7 @@ private let routers: [Router<Admin>] = [
     <¢> get <% end,
 
   .freeEpisodeEmail <<< .send
-    <¢> post %> lit("free-episode-email") %> pathParam(.int >>> .tagged) <% lit("send") <% end,
+    <¢> post %> lit("free-episode-email") %> pathParam(.tagged(.int)) <% lit("send") <% end,
 
   .freeEpisodeEmail <<< .index
     <¢> get %> lit("free-episode-email") <% end,
@@ -55,13 +55,13 @@ private let routers: [Router<Admin>] = [
     <¢> get %> lit("new-blog-post-email") <% end,
 
   .newBlogPostEmail <<< PartialIso.send
-    <¢> post %> lit("new-blog-post-email") %> pathParam(.int >>> .tagged) <%> lit("send")
+    <¢> post %> lit("new-blog-post-email") %> pathParam(.tagged(.int)) <%> lit("send")
     %> formBody(NewBlogPostFormData?.self, decoder: formDecoder)
     <%> isTest
     <% end,
 
   .newEpisodeEmail <<< PartialIso.send
-    <¢> post %> lit("new-episode-email") %> pathParam(.int >>> .tagged) <%> lit("send")
+    <¢> post %> lit("new-episode-email") %> pathParam(.tagged(.int)) <%> lit("send")
     %> formField("subscriber_announcement", .string).map(Optional.iso.some)
     <%> formField("nonsubscriber_announcement", .string).map(Optional.iso.some)
     <%> isTest

--- a/Sources/PointFreeRouter/Routes.swift
+++ b/Sources/PointFreeRouter/Routes.swift
@@ -93,7 +93,7 @@ private func routers(appSecret: String, mailgunApiKey: String) -> [Router<Route>
       <¢> get %> lit("blog") %> lit("feed") %> lit("atom.xml") <% end,
 
     .discounts
-      <¢> get %> lit("discounts") %> pathParam(.string >>> .tagged) <% end,
+      <¢> get %> lit("discounts") %> pathParam(.tagged(.string)) <% end,
 
     .blog <<< .index
       <¢> get %> lit("blog") <% end,
@@ -117,7 +117,7 @@ private func routers(appSecret: String, mailgunApiKey: String) -> [Router<Route>
 
     .expressUnsubscribe
       <¢> get %> lit("newsletters") %> lit("express-unsubscribe")
-      %> queryParam("payload", .decrypted(withSecret: appSecret) >>> payload(.uuid >>> .tagged, .rawRepresentable))
+      %> queryParam("payload", .decrypted(withSecret: appSecret) >>> payload(.tagged(.uuid), .rawRepresentable))
       <% end,
 
     .expressUnsubscribeReply
@@ -134,13 +134,13 @@ private func routers(appSecret: String, mailgunApiKey: String) -> [Router<Route>
       <¢> get <% end,
 
     .invite <<< .accept
-      <¢> post %> lit("invites") %> pathParam(.uuid >>> .tagged) <% lit("accept") <% end,
+      <¢> post %> lit("invites") %> pathParam(.tagged(.uuid)) <% lit("accept") <% end,
 
     .invite <<< .resend
-      <¢> post %> lit("invites") %> pathParam(.uuid >>> .tagged) <% lit("resend") <% end,
+      <¢> post %> lit("invites") %> pathParam(.tagged(.uuid)) <% lit("resend") <% end,
 
     .invite <<< .revoke
-      <¢> post %> lit("invites") %> pathParam(.uuid >>> .tagged) <% lit("revoke") <% end,
+      <¢> post %> lit("invites") %> pathParam(.tagged(.uuid)) <% lit("revoke") <% end,
 
     .invite <<< .send
       // TODO: this weird Optional.iso.some is cause `formField` takes a partial iso `String -> A` instead of
@@ -148,7 +148,7 @@ private func routers(appSecret: String, mailgunApiKey: String) -> [Router<Route>
       <¢> post %> lit("invites") %> formField("email", Optional.iso.some >>> opt(.rawRepresentable)) <% end,
 
     .invite <<< .show
-      <¢> get %> lit("invites") %> pathParam(.uuid >>> .tagged) <% end,
+      <¢> get %> lit("invites") %> pathParam(.tagged(.uuid)) <% end,
 
     .login
       <¢> get %> lit("login") %> queryParam("redirect", opt(.string)) <% end,
@@ -175,12 +175,12 @@ private func routers(appSecret: String, mailgunApiKey: String) -> [Router<Route>
 
     .team <<< .remove
       <¢> post %> lit("account") %> lit("team") %> lit("members")
-      %> pathParam(.uuid >>> .tagged)
+      %> pathParam(.tagged(.uuid))
       <% lit("remove")
       <% end,
 
     .useEpisodeCredit
-      <¢> post %> lit("episodes") %> pathParam(.int >>> .tagged) <% lit("credit") <% end,
+      <¢> post %> lit("episodes") %> pathParam(.tagged(.int)) <% lit("credit") <% end,
 
     .webhooks <<< .stripe <<< .event
       <¢> post %> lit("webhooks") %> lit("stripe")

--- a/Sources/PointFreeRouter/Util.swift
+++ b/Sources/PointFreeRouter/Util.swift
@@ -97,3 +97,16 @@ private func verify(payload: MailgunForwardPayload, apiKey: String) -> Bool {
   return payload.signature == digest
 
 }
+
+extension PartialIso {
+  /// Promotes a partial iso to one that deals with tagged values, e.g.
+  ///
+  ///    PartialIso<String, User.Id>.tagged(.string)
+  public static func tagged<T, C>(
+    _ iso: PartialIso<A, C>
+    ) -> PartialIso<A, B>
+    where B == Tagged<T, C> {
+
+      return iso >>> .tagged
+  }
+}


### PR DESCRIPTION
I wanted to play around with ideas of avoiding the `>>>` for very general partial isos, like the `.tagged` one. I think this reads pretty nicely. What do you think?

Also, it was great having the router in a module to test this. Instant compile times!