### PR TITLE
Remove brew upgrade step.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,6 @@ jobs:
           command: system_profiler SPSoftwareDataType
 
       - run:
-          name: Brew upgrade
-          command: brew upgrade || brew upgrade
-
-      - run:
           name: Install Postgres
           command: brew install postgresql
 


### PR DESCRIPTION
Removes 5 minutes from circle CI build times. I added it a few months ago to fix some weird circle problems, but seems to be ok now!