### PR TITLE
Fix inline video.

### DIFF
--- a/Sources/Views/EpisodeVideoView.swift
+++ b/Sources/Views/EpisodeVideoView.swift
@@ -48,8 +48,13 @@ private let videoJsClasses: CssSelector =
 public struct VideoJsOptions: Encodable {
   let control: Bool
   let playbackRates: [Double]
+  let playsinline: Bool
 
-  static let `default` = VideoJsOptions(control: true, playbackRates: [1, 1.25, 1.5, 1.75, 2])
+  static let `default` = VideoJsOptions(
+    control: true,
+    playbackRates: [1, 1.25, 1.5, 1.75, 2],
+    playsinline: true
+  )
 
   var jsonString: String {
     if #available(OSX 10.13, *) {

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_HasCredits.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_HasCredits.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 68490
+Content-Length: 68509
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2234,7 +2234,7 @@ that timestamp jumps the video to that spot.</p>
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/trailer.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_UsedCredit.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_UsedCredit.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 85791
+Content-Length: 85810
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2539,7 +2539,7 @@ video.play();event.preventDefault();"
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/video.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PublicEpisode_NonSubscriber_UsedCredit.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PublicEpisode_NonSubscriber_UsedCredit.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 85785
+Content-Length: 85804
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2539,7 +2539,7 @@ video.play();event.preventDefault();"
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/video.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 79002
+Content-Length: 79021
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2358,7 +2358,7 @@ that timestamp jumps the video to that spot.</p>
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/trailer.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 77498
+Content-Length: 77517
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2369,7 +2369,7 @@ working how we expect:</p>
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/video.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_ExercisesAndReferences.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_ExercisesAndReferences.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 68761
+Content-Length: 68780
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2240,7 +2240,7 @@ that timestamp jumps the video to that spot.</p>
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/video.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePage.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePage.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 87869
+Content-Length: 87888
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2494,7 +2494,7 @@ working how we expect:</p>
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/video.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePageSubscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePageSubscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 75930
+Content-Length: 75949
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2323,7 +2323,7 @@ working how we expect:</p>
                    playslinline
                    autoplay
                    poster
-                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2]}">
+                   data-setup="{"control":true,"playbackRates":[1,1.25,1.5,1.75,2],"playsinline":true}">
               <source src="https://s3.amazonaws.com/pointfreeco/video.m3u8"
                       type="application/vnd.apple.mpegurl">
             </video>


### PR DESCRIPTION
@krzyzanowskim [brought](https://twitter.com/krzyzanowskim/status/1146355372342611969) it to my attention that videos don't play inline on mobile. We use the `playsinline` attribute on the `video` tag, but apparently video.js overrides that, so I add to also add it to the video.js config.

