### PR TITLE
Simplify Subscribe Confirmation Data

### DIFF
--- a/Sources/Models/SubscribeConfirmationData.swift
+++ b/Sources/Models/SubscribeConfirmationData.swift
@@ -1,0 +1,15 @@
+import PointFreePrelude
+import Stripe
+
+public struct SubscribeConfirmationData: Equatable {
+  public var billing: Pricing.Billing
+  public var teammates: [EmailAddress]
+
+  public init(
+    billing: Pricing.Billing,
+    teammates: [EmailAddress]
+  ) {
+    self.billing = billing
+    self.teammates = teammates
+  }
+}

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -84,12 +84,7 @@ private func render(conn: Conn<StatusLineOpen, T3<(Models.Subscription, Enterpri
         |> blogMiddleware
 
     case let .discounts(couponId, billing):
-      let subscribeData = SubscribeData(
-        coupon: couponId,
-        pricing: Pricing(billing: billing ?? .yearly, quantity: 1),
-        teammates: [],
-        token: ""
-      )
+      let subscribeData = SubscribeConfirmationData(billing: billing ?? .yearly, teammates: [])
       return conn.map(const(user .*. route .*. subscriberState .*. .personal .*. subscribeData .*. couponId .*. unit))
         |> discountSubscribeConfirmation
 
@@ -170,9 +165,10 @@ private func render(conn: Conn<StatusLineOpen, T3<(Models.Subscription, Enterpri
         |> logoutResponse
 
     case .pricingLanding:
-      let allEpisodeCount = AllEpisodeCount(rawValue: Current.episodes().count)
-      let episodeHourCount = EpisodeHourCount(rawValue: Current.episodes().reduce(0) { $0 + $1.length } / 3600)
-      let freeEpisodeCount = FreeEpisodeCount(rawValue: Current.episodes().lazy.filter { $0.permission == .free }.count)
+      let episodes = Current.episodes()
+      let allEpisodeCount = AllEpisodeCount(rawValue: episodes.count)
+      let episodeHourCount = EpisodeHourCount(rawValue: episodes.reduce(0) { $0 + $1.length } / 3600)
+      let freeEpisodeCount = FreeEpisodeCount(rawValue: episodes.lazy.filter { $0.permission == .free }.count)
 
       return conn.map(const(
         user
@@ -194,12 +190,7 @@ private func render(conn: Conn<StatusLineOpen, T3<(Models.Subscription, Enterpri
 
     case let .subscribeConfirmation(lane, billing, teammates):
       let teammates = lane == .team ? (teammates ?? [""]) : []
-      let subscribeData = SubscribeData(
-        coupon: nil,
-        pricing: Pricing(billing: billing ?? .yearly, quantity: teammates.count + 1),
-        teammates: teammates,
-        token: ""
-      )
+      let subscribeData = SubscribeConfirmationData(billing: billing ?? .yearly, teammates: teammates)
       return conn.map(const(user .*. route .*. subscriberState .*. lane .*. subscribeData .*. nil .*. unit))
         |> subscribeConfirmation
 

--- a/Sources/PointFree/SubscribeConfirmation.swift
+++ b/Sources/PointFree/SubscribeConfirmation.swift
@@ -12,7 +12,7 @@ import Views
 public let subscribeConfirmation: Middleware<
   StatusLineOpen,
   ResponseEnded,
-  Tuple6<User?, Route, SubscriberState, Pricing.Lane, SubscribeConfirmationData?, Stripe.Coupon?>,
+  Tuple6<User?, Route, SubscriberState, Pricing.Lane, SubscribeConfirmationData, Stripe.Coupon?>,
   Data
   >
   = filterMap(require1 >>> pure, or: loginAndRedirect)
@@ -44,7 +44,7 @@ public let subscribeConfirmation: Middleware<
 public let discountSubscribeConfirmation: Middleware<
   StatusLineOpen,
   ResponseEnded,
-  Tuple6<User?, Route, SubscriberState, Pricing.Lane, SubscribeConfirmationData?, Stripe.Coupon.Id?>,
+  Tuple6<User?, Route, SubscriberState, Pricing.Lane, SubscribeConfirmationData, Stripe.Coupon.Id?>,
   Data
   >
   = filterMap(

--- a/Sources/PointFree/SubscribeConfirmation.swift
+++ b/Sources/PointFree/SubscribeConfirmation.swift
@@ -12,7 +12,7 @@ import Views
 public let subscribeConfirmation: Middleware<
   StatusLineOpen,
   ResponseEnded,
-  Tuple6<User?, Route, SubscriberState, Pricing.Lane, SubscribeData?, Stripe.Coupon?>,
+  Tuple6<User?, Route, SubscriberState, Pricing.Lane, SubscribeConfirmationData?, Stripe.Coupon?>,
   Data
   >
   = filterMap(require1 >>> pure, or: loginAndRedirect)
@@ -44,7 +44,7 @@ public let subscribeConfirmation: Middleware<
 public let discountSubscribeConfirmation: Middleware<
   StatusLineOpen,
   ResponseEnded,
-  Tuple6<User?, Route, SubscriberState, Pricing.Lane,  SubscribeData?, Stripe.Coupon.Id?>,
+  Tuple6<User?, Route, SubscriberState, Pricing.Lane, SubscribeConfirmationData?, Stripe.Coupon.Id?>,
   Data
   >
   = filterMap(

--- a/Sources/Views/SubscriptionConfirmation.swift
+++ b/Sources/Views/SubscriptionConfirmation.swift
@@ -13,7 +13,7 @@ import TaggedMoney
 
 public func subscriptionConfirmation(
   _ lane: Pricing.Lane,
-  _ subscribeData: SubscribeData?,
+  _ subscribeData: SubscribeConfirmationData?,
   _ coupon: Stripe.Coupon?,
   _ currentUser: User,
   _ stripeJs: String,
@@ -81,7 +81,7 @@ private func header(_ lane: Pricing.Lane) -> [Node] {
   ]
 }
 
-private func teamMembers(_ currentUser: User, _ subscribeData: SubscribeData?) -> [Node] {
+private func teamMembers(_ currentUser: User, _ subscribeData: SubscribeConfirmationData?) -> [Node] {
   return [
     gridRow(
       [`class`([moduleRowClass])],
@@ -266,7 +266,7 @@ updateSeats()
 private func billingPeriod(
   coupon: Coupon?,
   lane: Pricing.Lane,
-  subscribeData: SubscribeData?
+  subscribeData: SubscribeConfirmationData?
   ) -> [Node] {
   return [
     gridRow(
@@ -299,7 +299,7 @@ private func billingPeriod(
               [
                 div([
                   input([
-                    checked((subscribeData?.pricing.billing ?? .yearly) == .yearly),
+                    checked((subscribeData?.billing ?? .yearly) == .yearly),
                     id("yearly"),
                     type(.radio),
                     name("pricing[billing]"),
@@ -369,7 +369,7 @@ private func billingPeriod(
                 div(
                   [
                     input([
-                      checked(subscribeData?.pricing.billing == .monthly),
+                      checked(subscribeData?.billing == .monthly),
                       id("monthly"),
                       type(.radio),
                       name("pricing[billing]"),

--- a/Sources/Views/SubscriptionConfirmation.swift
+++ b/Sources/Views/SubscriptionConfirmation.swift
@@ -13,7 +13,7 @@ import TaggedMoney
 
 public func subscriptionConfirmation(
   _ lane: Pricing.Lane,
-  _ subscribeData: SubscribeConfirmationData?,
+  _ subscribeData: SubscribeConfirmationData,
   _ coupon: Stripe.Coupon?,
   _ currentUser: User,
   _ stripeJs: String,
@@ -81,7 +81,7 @@ private func header(_ lane: Pricing.Lane) -> [Node] {
   ]
 }
 
-private func teamMembers(_ currentUser: User, _ subscribeData: SubscribeConfirmationData?) -> [Node] {
+private func teamMembers(_ currentUser: User, _ subscribeData: SubscribeConfirmationData) -> [Node] {
   return [
     gridRow(
       [`class`([moduleRowClass])],
@@ -95,8 +95,7 @@ private func teamMembers(_ currentUser: User, _ subscribeData: SubscribeConfirma
         gridColumn(
           sizes: [.mobile: 12],
           [id("team-members")],
-          (subscribeData?.teammates ?? [""])
-            .map { teamMemberTemplate($0, withRemoveButton: false) }
+          subscribeData.teammates.map { teamMemberTemplate($0, withRemoveButton: false) }
         ),
         gridColumn(
           sizes: [.mobile: 12],
@@ -266,7 +265,7 @@ updateSeats()
 private func billingPeriod(
   coupon: Coupon?,
   lane: Pricing.Lane,
-  subscribeData: SubscribeConfirmationData?
+  subscribeData: SubscribeConfirmationData
   ) -> [Node] {
   return [
     gridRow(
@@ -299,7 +298,7 @@ private func billingPeriod(
               [
                 div([
                   input([
-                    checked((subscribeData?.billing ?? .yearly) == .yearly),
+                    checked(subscribeData.billing == .yearly),
                     id("yearly"),
                     type(.radio),
                     name("pricing[billing]"),
@@ -369,7 +368,7 @@ private func billingPeriod(
                 div(
                   [
                     input([
-                      checked(subscribeData?.billing == .monthly),
+                      checked(subscribeData.billing == .monthly),
                       id("monthly"),
                       type(.radio),
                       name("pricing[billing]"),


### PR DESCRIPTION
https://trello.com/c/r2kxgFLV/373-subscribeconfirmation-route-should-not-use-subscribedata