### PR TITLE
Add a foreign key for user's subscription id.

### DIFF
--- a/Sources/Database/Database.swift
+++ b/Sources/Database/Database.swift
@@ -1017,6 +1017,12 @@ private struct _Client {
       ON "enterprise_emails" ("user_id")
       """
       )))
+      .flatMap(const(execute(
+        """
+      ALTER TABLE "users"
+      ADD FOREIGN KEY ("subscription_id") REFERENCES "subscriptions" ("id")
+      """
+      )))
       .map(const(unit))
   }
 


### PR DESCRIPTION
I think this is just something we overlooked a long time ago. The users table `subscription_id` wasn't an actual foreign key pointing to `subscriptions.id`. This is never really problematic in production because we never delete subscriptions from the table, but it's still nice to have this constraint, and it can be useful for local development when messing with data manually.

https://trello.com/c/OFf9g5Qk