### PR TITLE
Force macOS 10.13 for the project.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
   name: "PointFree",
+  platforms: [
+    .macOS(.v10_13),
+  ],
   products: [
     .executable(name: "Runner", targets: ["Runner"]),
     .executable(name: "Server", targets: ["Server"]),

--- a/Sources/GitHub/Client.swift
+++ b/Sources/GitHub/Client.swift
@@ -91,11 +91,7 @@ private func runGitHub<A>(_ logger: Logger?) -> (DecodableRequest<A>) -> EitherI
 
 private let gitHubJsonEncoder: JSONEncoder = { () in
   let encoder = JSONEncoder()
-
-  if #available(OSX 10.13, *) {
-    encoder.outputFormatting = [.sortedKeys]
-  }
-
+  encoder.outputFormatting = [.sortedKeys]
   return encoder
 }()
 

--- a/Sources/PointFree/ApiMiddleware.swift
+++ b/Sources/PointFree/ApiMiddleware.swift
@@ -107,7 +107,7 @@ public func respondJson<A: Encodable>(
   ) -> IO<Conn<ResponseEnded, Data>> {
 
   let encoder = JSONEncoder()
-  if #available(OSX 10.13, *), Current.envVars.appEnv == .testing {
+  if Current.envVars.appEnv == .testing {
     encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
   }
   let data = try! encoder.encode(conn.data) // TODO: 400 on badly formed data

--- a/Sources/PointFree/Session.swift
+++ b/Sources/PointFree/Session.swift
@@ -193,10 +193,6 @@ private func setCookie<A: Encodable>(key: String, value: A, options: Set<Respons
 
 public let cookieJsonEncoder: JSONEncoder = { () in
   let encoder = JSONEncoder()
-
-  if #available(OSX 10.13, *) {
-    encoder.outputFormatting = [.sortedKeys]
-  }
-
+  encoder.outputFormatting = [.sortedKeys]
   return encoder
 }()

--- a/Sources/PointFreeTestSupport/TestCase.swift
+++ b/Sources/PointFreeTestSupport/TestCase.swift
@@ -45,7 +45,7 @@ open class TestCase: XCTestCase {
   }
 
   public var isScreenshotTestingAvailable: Bool {
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
       return true
     } else {
       return false

--- a/Sources/PointFreeTestSupport/TestCase.swift
+++ b/Sources/PointFreeTestSupport/TestCase.swift
@@ -43,4 +43,12 @@ open class TestCase: XCTestCase {
     super.tearDown()
     record = false
   }
+
+  public var isScreenshotTestingAvailable: Bool {
+    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+      return true
+    } else {
+      return false
+    }
+  }
 }

--- a/Sources/Views/EpisodeVideoView.swift
+++ b/Sources/Views/EpisodeVideoView.swift
@@ -126,17 +126,11 @@ public struct VideoJsOptions: Encodable {
   )
 
   var jsonString: String {
-    if #available(OSX 10.13, *) {
-      return ((try? String(data: jsonEncoder.encode(VideoJsOptions.default), encoding: .utf8)) ?? nil)
-        ?? "{}"
-    } else {
-      return ((try? String(data: JSONEncoder().encode(VideoJsOptions.default), encoding: .utf8)) ?? nil)
-        ?? "{}"
-    }
+    return ((try? String(data: jsonEncoder.encode(VideoJsOptions.default), encoding: .utf8)) ?? nil)
+      ?? "{}"
   }
 }
 
-@available(OSX 10.13, *)
 private let jsonEncoder: JSONEncoder = {
   let encoder = JSONEncoder()
   encoder.outputFormatting = .sortedKeys

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -12,6 +12,7 @@ extension AboutTests {
 extension AccountTests {
   static var allTests: [(String, (AccountTests) -> () throws -> Void)] = [
     ("testAccount", testAccount),
+    ("testAccount_InvoiceBilling", testAccount_InvoiceBilling),
     ("testAccount_WithRssFeatureFlag", testAccount_WithRssFeatureFlag),
     ("testTeam_OwnerIsNotSubscriber", testTeam_OwnerIsNotSubscriber),
     ("testTeam_NoRemainingSeats", testTeam_NoRemainingSeats),
@@ -26,6 +27,13 @@ extension AccountTests {
     ("testEpisodeCredits_1Credit_NoneChosen", testEpisodeCredits_1Credit_NoneChosen),
     ("testEpisodeCredits_1Credit_1Chosen", testEpisodeCredits_1Credit_1Chosen),
     ("testAccountWithDiscount", testAccountWithDiscount),
+  ]
+}
+extension ApiTests {
+  static var allTests: [(String, (ApiTests) -> () throws -> Void)] = [
+    ("testEpisodes", testEpisodes),
+    ("testEpisode", testEpisode),
+    ("testEpisode_NotFound", testEpisode_NotFound),
   ]
 }
 extension AppleDeveloperMerchantIdDomainAssociationTests {
@@ -98,6 +106,7 @@ extension ChangeEmailConfirmationTests {
 }
 extension ChangeTests {
   static var allTests: [(String, (ChangeTests) -> () throws -> Void)] = [
+    ("testChangeRedirect", testChangeRedirect),
     ("testChangeUpdateUpgradeIndividualPlan", testChangeUpdateUpgradeIndividualPlan),
     ("testChangeUpdateDowngradeIndividualPlan", testChangeUpdateDowngradeIndividualPlan),
     ("testChangeUpdateUpgradeTeamPlan", testChangeUpdateUpgradeTeamPlan),
@@ -194,6 +203,14 @@ extension FunctionalCssTests {
     ("testFunctionalCss", testFunctionalCss),
   ]
 }
+extension GhostTests {
+  static var allTests: [(String, (GhostTests) -> () throws -> Void)] = [
+    ("testStartGhosting_HappyPath", testStartGhosting_HappyPath),
+    ("testStartGhosting_InvalidGhostee", testStartGhosting_InvalidGhostee),
+    ("testStartGhosting_NonAdmin", testStartGhosting_NonAdmin),
+    ("testEndGhosting_HappyPath", testEndGhosting_HappyPath),
+  ]
+}
 extension GitHubTests {
   static var allTests: [(String, (GitHubTests) -> () throws -> Void)] = [
     ("testRequests", testRequests),
@@ -224,12 +241,14 @@ extension InviteTests {
     ("testAcceptInvitation_InviterIsNotSubscriber", testAcceptInvitation_InviterIsNotSubscriber),
     ("testAcceptInvitation_InviterHasInactiveStripeSubscription", testAcceptInvitation_InviterHasInactiveStripeSubscription),
     ("testAcceptInvitation_InviterHasCancelingStripeSubscription", testAcceptInvitation_InviterHasCancelingStripeSubscription),
+    ("testAddTeammate", testAddTeammate),
   ]
 }
 extension InvoicesTests {
   static var allTests: [(String, (InvoicesTests) -> () throws -> Void)] = [
     ("testInvoices", testInvoices),
     ("testInvoice", testInvoice),
+    ("testInvoice_InvoiceBilling", testInvoice_InvoiceBilling),
     ("testInvoiceWithDiscount", testInvoiceWithDiscount),
   ]
 }
@@ -279,6 +298,7 @@ extension NotFoundMiddlewareTests {
 extension PaymentInfoTests {
   static var allTests: [(String, (PaymentInfoTests) -> () throws -> Void)] = [
     ("testRender", testRender),
+    ("testInvoiceBilling", testInvoiceBilling),
   ]
 }
 extension PointFreeRouterTests {
@@ -312,6 +332,12 @@ extension RegistrationEmailTests {
     ("testRegistrationEmail", testRegistrationEmail),
   ]
 }
+extension SessionTests {
+  static var allTests: [(String, (SessionTests) -> () throws -> Void)] = [
+    ("testEncodable", testEncodable),
+    ("testDecodable", testDecodable),
+  ]
+}
 extension SiteMiddlewareTests {
   static var allTests: [(String, (SiteMiddlewareTests) -> () throws -> Void)] = [
     ("testWithoutWWW", testWithoutWWW),
@@ -324,6 +350,8 @@ extension StripeTests {
   static var allTests: [(String, (StripeTests) -> () throws -> Void)] = [
     ("testDecodingCustomer", testDecodingCustomer),
     ("testDecodingCustomer_Metadata", testDecodingCustomer_Metadata),
+    ("testDecodingPlan_WithoutNickname", testDecodingPlan_WithoutNickname),
+    ("testDecodingPlan_WithNickname", testDecodingPlan_WithNickname),
     ("testDecodingSubscriptionWithDiscount", testDecodingSubscriptionWithDiscount),
     ("testDecodingDiscountJson", testDecodingDiscountJson),
     ("testRequests", testRequests),
@@ -335,6 +363,7 @@ extension StripeWebhooksTests {
     ("testValidHook", testValidHook),
     ("testStaleHook", testStaleHook),
     ("testInvalidHook", testInvalidHook),
+    ("testNoSubscriptionId", testNoSubscriptionId),
     ("testPastDueEmail", testPastDueEmail),
   ]
 }
@@ -351,6 +380,7 @@ extension SubscribeTests {
   static var allTests: [(String, (SubscribeTests) -> () throws -> Void)] = [
     ("testNotLoggedIn_IndividualMonthly", testNotLoggedIn_IndividualMonthly),
     ("testCoupon_Individual", testCoupon_Individual),
+    ("testCouponFailure_Individual", testCouponFailure_Individual),
     ("testCoupon_Team", testCoupon_Team),
     ("testNotLoggedIn_IndividualYearly", testNotLoggedIn_IndividualYearly),
     ("testNotLoggedIn_Team", testNotLoggedIn_Team),
@@ -360,15 +390,22 @@ extension SubscribeTests {
     ("testHappyPath_Team", testHappyPath_Team),
     ("testCreateCustomerFailure", testCreateCustomerFailure),
     ("testCreateStripeSubscriptionFailure", testCreateStripeSubscriptionFailure),
+    ("testCreateStripeSubscriptionFailure_TeamAndMonthly", testCreateStripeSubscriptionFailure_TeamAndMonthly),
+    ("testCreateStripeSubscriptionFailure_TeamAndMonthly_TooManyEmails", testCreateStripeSubscriptionFailure_TeamAndMonthly_TooManyEmails),
     ("testCreateDatabaseSubscriptionFailure", testCreateDatabaseSubscriptionFailure),
   ]
 }
 extension SubscriptionConfirmationTests {
   static var allTests: [(String, (SubscriptionConfirmationTests) -> () throws -> Void)] = [
     ("testPersonal_LoggedIn", testPersonal_LoggedIn),
+    ("testPersonal_LoggedIn_SwitchToMonthly", testPersonal_LoggedIn_SwitchToMonthly),
     ("testTeam_LoggedIn", testTeam_LoggedIn),
+    ("testTeam_LoggedIn_WithDefaults", testTeam_LoggedIn_WithDefaults),
+    ("testTeam_LoggedIn_SwitchToMonthly", testTeam_LoggedIn_SwitchToMonthly),
+    ("testTeam_LoggedIn_AddTeamMember", testTeam_LoggedIn_AddTeamMember),
     ("testPersonal_LoggedIn_ActiveSubscriber", testPersonal_LoggedIn_ActiveSubscriber),
     ("testPersonal_LoggedOut", testPersonal_LoggedOut),
+    ("testPersonal_LoggedIn_WithDiscount", testPersonal_LoggedIn_WithDiscount),
   ]
 }
 extension TeamEmailsTests {
@@ -398,6 +435,7 @@ extension WelcomeEmailTests {
 XCTMain([
   testCase(AboutTests.allTests),
   testCase(AccountTests.allTests),
+  testCase(ApiTests.allTests),
   testCase(AppleDeveloperMerchantIdDomainAssociationTests.allTests),
   testCase(AtomFeedTests.allTests),
   testCase(AuthTests.allTests),
@@ -417,6 +455,7 @@ XCTMain([
   testCase(EpisodeTests.allTests),
   testCase(FreeEpisodeEmailTests.allTests),
   testCase(FunctionalCssTests.allTests),
+  testCase(GhostTests.allTests),
   testCase(GitHubTests.allTests),
   testCase(HomeTests.allTests),
   testCase(HtmlCssInlinerTests.allTests),
@@ -434,6 +473,7 @@ XCTMain([
   testCase(PrivacyTests.allTests),
   testCase(PrivateRssTests.allTests),
   testCase(RegistrationEmailTests.allTests),
+  testCase(SessionTests.allTests),
   testCase(SiteMiddlewareTests.allTests),
   testCase(StripeTests.allTests),
   testCase(StripeWebhooksTests.allTests),

--- a/Tests/PointFreeTests/AboutTests.swift
+++ b/Tests/PointFreeTests/AboutTests.swift
@@ -17,7 +17,7 @@ class AboutTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/AccountTests/AccountTests.swift
+++ b/Tests/PointFreeTests/AccountTests/AccountTests.swift
@@ -33,7 +33,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -58,7 +58,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -79,7 +79,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -109,7 +109,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -142,7 +142,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -162,7 +162,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -191,7 +191,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -212,7 +212,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -232,7 +232,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -252,7 +252,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -276,7 +276,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -296,7 +296,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -316,7 +316,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -344,7 +344,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -373,7 +373,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -396,7 +396,7 @@ final class AccountTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/AccountTests/CancelTests.swift
+++ b/Tests/PointFreeTests/AccountTests/CancelTests.swift
@@ -72,7 +72,7 @@ final class CancelTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 800, height: 800))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -134,7 +134,7 @@ final class CancelTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 800, height: 800))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
+++ b/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
@@ -27,7 +27,7 @@ class PaymentInfoTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/ApiTests.swift
+++ b/Tests/PointFreeTests/ApiTests.swift
@@ -25,7 +25,7 @@ final class ApiTests: TestCase {
       |> Prelude.perform
 
     #if !os(Linux)
-    // Necessary because of https://bugs.swift.org/browse/SR-11410
+    // Can't run on Linux because of https://bugs.swift.org/browse/SR-11410
     assertSnapshot(matching: conn, as: .conn)
     #endif
   }

--- a/Tests/PointFreeTests/ApiTests.swift
+++ b/Tests/PointFreeTests/ApiTests.swift
@@ -24,7 +24,9 @@ final class ApiTests: TestCase {
       |> siteMiddleware
       |> Prelude.perform
 
+    #if !os(Linux)
     assertSnapshot(matching: conn, as: .conn)
+    #endif
   }
 
   func testEpisode_NotFound() {

--- a/Tests/PointFreeTests/ApiTests.swift
+++ b/Tests/PointFreeTests/ApiTests.swift
@@ -25,6 +25,7 @@ final class ApiTests: TestCase {
       |> Prelude.perform
 
     #if !os(Linux)
+    // Necessary because of https://bugs.swift.org/browse/SR-11410
     assertSnapshot(matching: conn, as: .conn)
     #endif
   }

--- a/Tests/PointFreeTests/BlogTests.swift
+++ b/Tests/PointFreeTests/BlogTests.swift
@@ -28,7 +28,7 @@ class BlogTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -52,7 +52,7 @@ class BlogTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -77,7 +77,7 @@ class BlogTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/EmailTests/ChangeEmailConfirmationTests.swift
+++ b/Tests/PointFreeTests/EmailTests/ChangeEmailConfirmationTests.swift
@@ -22,7 +22,7 @@ class ChangeEmailConfirmationTests: TestCase {
     assertSnapshot(matching: emailNodes, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 600, height: 800))
       webView.loadHTMLString(render(emailNodes), baseURL: nil)
 
@@ -37,7 +37,7 @@ class ChangeEmailConfirmationTests: TestCase {
     assertSnapshot(matching: emailNodes, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 600, height: 800))
       webView.loadHTMLString(render(emailNodes), baseURL: nil)
 

--- a/Tests/PointFreeTests/EmailTests/FreeEpisodeEmailTests.swift
+++ b/Tests/PointFreeTests/EmailTests/FreeEpisodeEmailTests.swift
@@ -24,7 +24,7 @@ class FreeEpisodeEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/PointFreeTests/EmailTests/InviteEmailTests.swift
+++ b/Tests/PointFreeTests/EmailTests/InviteEmailTests.swift
@@ -24,7 +24,7 @@ class EmailInviteTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 800, height: 800))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -42,7 +42,7 @@ class EmailInviteTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 800, height: 800))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/PointFreeTests/EmailTests/NewBlogPostEmailTests.swift
+++ b/Tests/PointFreeTests/EmailTests/NewBlogPostEmailTests.swift
@@ -28,7 +28,7 @@ class NewBlogPostEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -46,7 +46,7 @@ class NewBlogPostEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -64,7 +64,7 @@ class NewBlogPostEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -82,7 +82,7 @@ class NewBlogPostEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/PointFreeTests/EmailTests/NewEpisodeEmailTests.swift
+++ b/Tests/PointFreeTests/EmailTests/NewEpisodeEmailTests.swift
@@ -24,7 +24,7 @@ class NewEpisodeEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -45,7 +45,7 @@ class NewEpisodeEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -70,7 +70,7 @@ class NewEpisodeEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -95,7 +95,7 @@ class NewEpisodeEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/PointFreeTests/EmailTests/RegistrationEmailTests.swift
+++ b/Tests/PointFreeTests/EmailTests/RegistrationEmailTests.swift
@@ -25,7 +25,7 @@ class RegistrationEmailTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 900, height: 1200))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/PointFreeTests/EmailTests/TeamEmailsTests.swift
+++ b/Tests/PointFreeTests/EmailTests/TeamEmailsTests.swift
@@ -22,7 +22,7 @@ class TeamEmailsTests: TestCase {
     assertSnapshot(matching: emailNodes, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 600, height: 800))
       webView.loadHTMLString(render(emailNodes), baseURL: nil)
 
@@ -37,7 +37,7 @@ class TeamEmailsTests: TestCase {
     assertSnapshot(matching: emailNodes, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 600, height: 800))
       webView.loadHTMLString(render(emailNodes), baseURL: nil)
 

--- a/Tests/PointFreeTests/EmailTests/WelcomeEmailTests.swift
+++ b/Tests/PointFreeTests/EmailTests/WelcomeEmailTests.swift
@@ -27,7 +27,7 @@ final class WelcomeEmailTests: TestCase {
     assertSnapshot(matching: emailNodes, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 600, height: 800))
       webView.loadHTMLString(render(emailNodes), baseURL: nil)
 
@@ -44,7 +44,7 @@ final class WelcomeEmailTests: TestCase {
     assertSnapshot(matching: emailNodes, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 600, height: 800))
       webView.loadHTMLString(render(emailNodes), baseURL: nil)
 
@@ -61,7 +61,7 @@ final class WelcomeEmailTests: TestCase {
     assertSnapshot(matching: emailNodes, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 600, height: 800))
       webView.loadHTMLString(render(emailNodes), baseURL: nil)
 

--- a/Tests/PointFreeTests/EnterpriseTests.swift
+++ b/Tests/PointFreeTests/EnterpriseTests.swift
@@ -33,7 +33,7 @@ class EnterpriseTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/EpisodePageTests.swift
+++ b/Tests/PointFreeTests/EpisodePageTests.swift
@@ -34,7 +34,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -55,7 +55,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -84,7 +84,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -113,7 +113,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -135,7 +135,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshot(
         matching: conn |> siteMiddleware,
         as: .ioConnWebView(size: .init(width: 1100, height: 1000))
@@ -168,7 +168,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -204,7 +204,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -240,7 +240,7 @@ class EpisodePageTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -418,7 +418,7 @@ class EpisodePageTests: TestCase {
     )
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
       let html = String(decoding: siteMiddleware(conn).perform().data, as: UTF8.self)
       webView.loadHTMLString(html, baseURL: nil)

--- a/Tests/PointFreeTests/HomeTests.swift
+++ b/Tests/PointFreeTests/HomeTests.swift
@@ -43,7 +43,7 @@ class HomeTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1080, height: 3000))
       webView.loadHTMLString(String(decoding: result.perform().data, as: UTF8.self), baseURL: nil)
       assertSnapshot(matching: webView, as: .image, named: "desktop")
@@ -62,7 +62,7 @@ class HomeTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/InviteTests.swift
+++ b/Tests/PointFreeTests/InviteTests.swift
@@ -30,7 +30,7 @@ class InviteTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -62,7 +62,7 @@ class InviteTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/InvoicesTests.swift
+++ b/Tests/PointFreeTests/InvoicesTests.swift
@@ -26,7 +26,7 @@ final class InvoicesTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -44,7 +44,7 @@ final class InvoicesTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -69,7 +69,7 @@ final class InvoicesTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -93,7 +93,7 @@ final class InvoicesTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/MinimalNavViewTests.swift
+++ b/Tests/PointFreeTests/MinimalNavViewTests.swift
@@ -34,7 +34,7 @@ class MinimalNavViewTests: TestCase {
       let doc = testDocView.view(state)
 
       #if !os(Linux)
-      if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+      if self.isScreenshotTestingAvailable {
         let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 180))
         webView.loadHTMLString(render(doc), baseURL: nil)
         assertSnapshot(matching: webView, as: .image, named: "\(key)_desktop")

--- a/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
+++ b/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
@@ -25,7 +25,7 @@ final class NotFoundMiddlewareTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -46,7 +46,7 @@ final class NotFoundMiddlewareTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/PricingLandingTests.swift
+++ b/Tests/PointFreeTests/PricingLandingTests.swift
@@ -33,7 +33,7 @@ class PricingLandingTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -58,7 +58,7 @@ class PricingLandingTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -77,7 +77,7 @@ class PricingLandingTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/PrivacyTests.swift
+++ b/Tests/PointFreeTests/PrivacyTests.swift
@@ -21,7 +21,7 @@ class PrivacyTests: TestCase {
     assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/PointFreeTests/SessionTests.swift
+++ b/Tests/PointFreeTests/SessionTests.swift
@@ -15,7 +15,7 @@ final class SessionTests: TestCase {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
-    _assertInlineSnapshot(matching: Session(flash: nil, user: nil), as: .json(JSONEncoder()), with: """
+    _assertInlineSnapshot(matching: Session(flash: nil, user: nil), as: .json(encoder), with: """
 {}
 """)
 
@@ -23,7 +23,7 @@ final class SessionTests: TestCase {
       flash: nil,
       user: .standard(User.Id(rawValue: UUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef")!))
     )
-    _assertInlineSnapshot(matching: session, as: .json(JSONEncoder()), with: """
+    _assertInlineSnapshot(matching: session, as: .json(encoder), with: """
 {"userId":"DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF"}
 """)
 
@@ -34,7 +34,7 @@ final class SessionTests: TestCase {
         ghosterId: User.Id(rawValue: UUID(uuidString: "99999999-dead-beef-dead-beefdeadbeef")!)
       )
     )
-    _assertInlineSnapshot(matching: session, as: .json(JSONEncoder()), with: """
+    _assertInlineSnapshot(matching: session, as: .json(encoder), with: """
 {"user":{"ghosteeId":"00000000-DEAD-BEEF-DEAD-BEEFDEADBEEF","ghosterId":"99999999-DEAD-BEEF-DEAD-BEEFDEADBEEF"}}
 """)
   }

--- a/Tests/PointFreeTests/SessionTests.swift
+++ b/Tests/PointFreeTests/SessionTests.swift
@@ -16,7 +16,9 @@ final class SessionTests: TestCase {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
     _assertInlineSnapshot(matching: Session(flash: nil, user: nil), as: .json(encoder), with: """
-{}
+{
+
+}
 """)
 
     session = Session(
@@ -24,7 +26,9 @@ final class SessionTests: TestCase {
       user: .standard(User.Id(rawValue: UUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef")!))
     )
     _assertInlineSnapshot(matching: session, as: .json(encoder), with: """
-{"userId":"DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF"}
+{
+  "userId" : "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF"
+}
 """)
 
     session = Session(
@@ -35,7 +39,12 @@ final class SessionTests: TestCase {
       )
     )
     _assertInlineSnapshot(matching: session, as: .json(encoder), with: """
-{"user":{"ghosteeId":"00000000-DEAD-BEEF-DEAD-BEEFDEADBEEF","ghosterId":"99999999-DEAD-BEEF-DEAD-BEEFDEADBEEF"}}
+{
+  "user" : {
+    "ghosteeId" : "00000000-DEAD-BEEF-DEAD-BEEFDEADBEEF",
+    "ghosterId" : "99999999-DEAD-BEEF-DEAD-BEEFDEADBEEF"
+  }
+}
 """)
   }
 

--- a/Tests/PointFreeTests/SessionTests.swift
+++ b/Tests/PointFreeTests/SessionTests.swift
@@ -12,6 +12,8 @@ final class SessionTests: TestCase {
 
   func testEncodable() {
     var session: Session
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
     _assertInlineSnapshot(matching: Session(flash: nil, user: nil), as: .json(JSONEncoder()), with: """
 {}

--- a/Tests/PointFreeTests/SessionTests.swift
+++ b/Tests/PointFreeTests/SessionTests.swift
@@ -15,11 +15,14 @@ final class SessionTests: TestCase {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
+    #if !os(Linux)
+    // Can't run on Linux because of https://bugs.swift.org/browse/SR-11410
     _assertInlineSnapshot(matching: Session(flash: nil, user: nil), as: .json(encoder), with: """
 {
 
 }
 """)
+    #endif
 
     session = Session(
       flash: nil,

--- a/Tests/PointFreeTests/StripeWebhooksTests.swift
+++ b/Tests/PointFreeTests/StripeWebhooksTests.swift
@@ -195,7 +195,7 @@ final class StripeWebhooksTests: TestCase {
     assertSnapshot(matching: plainText(for: doc), as: .lines)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 800, height: 800))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/PointFreeTests/SubscribeConfirmationTests.swift
+++ b/Tests/PointFreeTests/SubscribeConfirmationTests.swift
@@ -33,7 +33,7 @@ class SubscriptionConfirmationTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -57,7 +57,7 @@ class SubscriptionConfirmationTests: TestCase {
     let result = conn |> siteMiddleware
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
       let html = String(decoding: result.perform().data, as: UTF8.self)
       webView.loadHTMLString(html, baseURL: nil)
@@ -85,7 +85,7 @@ class SubscriptionConfirmationTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -120,7 +120,7 @@ class SubscriptionConfirmationTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [
@@ -144,7 +144,7 @@ class SubscriptionConfirmationTests: TestCase {
     let result = conn |> siteMiddleware
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
       let html = String(decoding: result.perform().data, as: UTF8.self)
       webView.loadHTMLString(html, baseURL: nil)
@@ -170,7 +170,7 @@ class SubscriptionConfirmationTests: TestCase {
     let result = conn |> siteMiddleware
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
       let html = String(decoding: result.perform().data, as: UTF8.self)
       webView.loadHTMLString(html, baseURL: nil)
@@ -226,7 +226,7 @@ class SubscriptionConfirmationTests: TestCase {
     assertSnapshot(matching: result, as: .ioConn)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       assertSnapshots(
         matching: conn |> siteMiddleware,
         as: [

--- a/Tests/StyleguideTests/StyleguideTests.swift
+++ b/Tests/StyleguideTests/StyleguideTests.swift
@@ -46,7 +46,7 @@ class StyleguideTests: XCTestCase {
     assertSnapshot(matching: doc, as: .html)
 
     #if !os(Linux)
-    if self.isScreenshotTestingAvailable {
+    if ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
       let webView = WKWebView.init(frame: NSRect(x: 0, y: 0, width: 190, height: 40))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -75,7 +75,7 @@ class StyleguideTests: XCTestCase {
     assertSnapshot(matching: doc, as: .html)
 
     #if !os(Linux)
-    if self.isScreenshotTestingAvailable {
+    if ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
       let webView = WKWebView.init(frame: NSRect(x: 0, y: 0, width: 190, height: 40))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -99,7 +99,7 @@ class StyleguideTests: XCTestCase {
     assertSnapshot(matching: doc, as: .html)
 
     #if !os(Linux)
-    if self.isScreenshotTestingAvailable {
+    if ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
       let webView = WKWebView.init(frame: NSRect(x: 0, y: 0, width: 80, height: 36))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)

--- a/Tests/StyleguideTests/StyleguideTests.swift
+++ b/Tests/StyleguideTests/StyleguideTests.swift
@@ -46,7 +46,7 @@ class StyleguideTests: XCTestCase {
     assertSnapshot(matching: doc, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView.init(frame: NSRect(x: 0, y: 0, width: 190, height: 40))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -75,7 +75,7 @@ class StyleguideTests: XCTestCase {
     assertSnapshot(matching: doc, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView.init(frame: NSRect(x: 0, y: 0, width: 190, height: 40))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)
@@ -99,7 +99,7 @@ class StyleguideTests: XCTestCase {
     assertSnapshot(matching: doc, as: .html)
 
     #if !os(Linux)
-    if #available(OSX 10.13, *), ProcessInfo.processInfo.environment["CIRCLECI"] == nil {
+    if self.isScreenshotTestingAvailable {
       let webView = WKWebView.init(frame: NSRect(x: 0, y: 0, width: 80, height: 36))
       webView.loadHTMLString(render(doc), baseURL: nil)
       assertSnapshot(matching: webView, as: .image)


### PR DESCRIPTION
While working on #495 I realized that we weren't running all tests on linux, which made me realize that some tests were failing on linux due to json encoding. We can just force the generated project to be macOS 10.13 now so that we can properly sort json encoding keys.