### PR TITLE
Fix stripe webooks for invoices without subscription ids.

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -363,7 +363,8 @@ extension StripeWebhooksTests {
     ("testValidHook", testValidHook),
     ("testStaleHook", testStaleHook),
     ("testInvalidHook", testInvalidHook),
-    ("testNoSubscriptionId", testNoSubscriptionId),
+    ("testNoInvoiceSubscriptionId", testNoInvoiceSubscriptionId),
+    ("testNoInvoiceSubscriptionId_AndNoLineItemSubscriptionId", testNoInvoiceSubscriptionId_AndNoLineItemSubscriptionId),
     ("testPastDueEmail", testPastDueEmail),
   ]
 }

--- a/Tests/PointFreeTests/StripeWebhooksTests.swift
+++ b/Tests/PointFreeTests/StripeWebhooksTests.swift
@@ -204,7 +204,7 @@ final class StripeWebhooksTests: TestCase {
 
     var hook = request(to: .webhooks(.stripe(.knownEvent(event))))
     hook.addValue(
-      "t=\(Int(Current.date().timeIntervalSince1970)),v1=bda3ac3f25b3665eac23aa47f7d521d7cb4578a70cbebf3aeab108e8c1a4a461",
+      "t=\(Int(Current.date().timeIntervalSince1970)),v1=950becadb9b19c86003ad07e745cc0b99a50f76b362bb50d5fe159c1f84c606f",
       forHTTPHeaderField: "Stripe-Signature"
     )
 

--- a/Tests/PointFreeTests/StripeWebhooksTests.swift
+++ b/Tests/PointFreeTests/StripeWebhooksTests.swift
@@ -166,10 +166,36 @@ final class StripeWebhooksTests: TestCase {
     #endif
   }
 
-  func testNoSubscriptionId() {
+  func testNoInvoiceSubscriptionId() {
     #if !os(Linux)
     let invoice = Invoice.mock(charge: .left("ch_test"))
       |> \.subscription .~ nil
+    let event = Event<Either<Invoice, Subscription>>(
+      data: .init(object: .left(invoice)),
+      id: "evt_test",
+      type: .invoicePaymentFailed
+    )
+
+    var hook = request(to: .webhooks(.stripe(.knownEvent(event))))
+    hook.addValue(
+      "t=\(Int(Current.date().timeIntervalSince1970)),v1=bda3ac3f25b3665eac23aa47f7d521d7cb4578a70cbebf3aeab108e8c1a4a461",
+      forHTTPHeaderField: "Stripe-Signature"
+    )
+
+    let conn = connection(from: hook)
+
+    assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    #endif
+  }
+
+  func testNoInvoiceSubscriptionId_AndNoLineItemSubscriptionId() {
+    #if !os(Linux)
+    let invoice = Invoice.mock(charge: .left("ch_test"))
+      |> \.subscription .~ nil
+      |> \.lines.data .~ [
+        .mock
+          |> \.subscription .~ nil
+    ]
     let event = Event<Either<Invoice, Subscription>>(
       data: .init(object: .left(invoice)),
       id: "evt_test",

--- a/Tests/PointFreeTests/__Snapshots__/StripeWebhooksTests/testNoInvoiceSubscriptionId.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/StripeWebhooksTests/testNoInvoiceSubscriptionId.1.Conn.txt
@@ -4,14 +4,10 @@ Stripe-Signature: t=1517356800,v1=bda3ac3f25b3665eac23aa47f7d521d7cb4578a70cbebf
 
 {"id":"evt_test","data":{"object":{"id":"in_test","amount_paid":1700,"customer":"cus_test","lines":{"has_more":false,"data":[{"amount":1700,"id":"ii_test","quantity":1,"subscription":"sub_test","plan":{"amount":1700,"name":"Individual Monthly","id":"monthly-2019","nickname":"Individual Monthly","created":1517356800,"tiers":[{"amount":1600},{"amount":1800}],"currency":"usd","metadata":{},"interval":"month"}}]},"charge":"ch_test","total":1700,"period_start":1517356800,"subtotal":1700,"amount_remaining":0,"date":1517356800,"period_end":1519948800,"number":"0000000-0000"}},"type":"invoice.payment_failed"}
 
-400 Bad Request
-Content-Length: 52
-Content-Type: text/plain
+200 OK
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
 X-Download-Options: noopen
 X-Frame-Options: SAMEORIGIN
 X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
-
-Couldn't extract subscription id from event payload.

--- a/Tests/PointFreeTests/__Snapshots__/StripeWebhooksTests/testNoInvoiceSubscriptionId_AndNoLineItemSubscriptionId.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/StripeWebhooksTests/testNoInvoiceSubscriptionId_AndNoLineItemSubscriptionId.1.Conn.txt
@@ -1,11 +1,11 @@
 POST http://localhost:8080/webhooks/stripe
 Cookie: pf_session={}
-Stripe-Signature: t=1517356800,v1=bda3ac3f25b3665eac23aa47f7d521d7cb4578a70cbebf3aeab108e8c1a4a461
+Stripe-Signature: t=1517356800,v1=950becadb9b19c86003ad07e745cc0b99a50f76b362bb50d5fe159c1f84c606f
 
 {"id":"evt_test","data":{"object":{"id":"in_test","amount_paid":1700,"customer":"cus_test","lines":{"has_more":false,"data":[{"amount":1700,"id":"ii_test","quantity":1,"plan":{"amount":1700,"name":"Individual Monthly","id":"monthly-2019","nickname":"Individual Monthly","created":1517356800,"tiers":[{"amount":1600},{"amount":1800}],"currency":"usd","metadata":{},"interval":"month"}}]},"charge":"ch_test","total":1700,"period_start":1517356800,"subtotal":1700,"amount_remaining":0,"date":1517356800,"period_end":1519948800,"number":"0000000-0000"}},"type":"invoice.payment_failed"}
 
 400 Bad Request
-Content-Length: 26
+Content-Length: 52
 Content-Type: text/plain
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -14,4 +14,4 @@ X-Frame-Options: SAMEORIGIN
 X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 
-Couldn't verify signature.
+Couldn't extract subscription id from event payload.

--- a/Tests/PointFreeTests/__Snapshots__/StripeWebhooksTests/testNoInvoiceSubscriptionId_AndNoLineItemSubscriptionId.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/StripeWebhooksTests/testNoInvoiceSubscriptionId_AndNoLineItemSubscriptionId.1.Conn.txt
@@ -1,0 +1,17 @@
+POST http://localhost:8080/webhooks/stripe
+Cookie: pf_session={}
+Stripe-Signature: t=1517356800,v1=bda3ac3f25b3665eac23aa47f7d521d7cb4578a70cbebf3aeab108e8c1a4a461
+
+{"id":"evt_test","data":{"object":{"id":"in_test","amount_paid":1700,"customer":"cus_test","lines":{"has_more":false,"data":[{"amount":1700,"id":"ii_test","quantity":1,"plan":{"amount":1700,"name":"Individual Monthly","id":"monthly-2019","nickname":"Individual Monthly","created":1517356800,"tiers":[{"amount":1600},{"amount":1800}],"currency":"usd","metadata":{},"interval":"month"}}]},"charge":"ch_test","total":1700,"period_start":1517356800,"subtotal":1700,"amount_remaining":0,"date":1517356800,"period_end":1519948800,"number":"0000000-0000"}},"type":"invoice.payment_failed"}
+
+400 Bad Request
+Content-Length: 26
+Content-Type: text/plain
+Referrer-Policy: strict-origin-when-cross-origin
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: SAMEORIGIN
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+
+Couldn't verify signature.


### PR DESCRIPTION
Turns out many stripe hooks come with invoices that don't have subscriptions attached. For those we can search the invoice line items to find the subscription.