### PR TITLE
More webhook failure messaging.

### DIFF
--- a/Sources/Database/Database.swift
+++ b/Sources/Database/Database.swift
@@ -297,7 +297,7 @@ private struct _Client {
     UPDATE "subscriptions"
     SET "stripe_subscription_status" = $1
     WHERE "subscriptions"."stripe_subscription_id" = $2
-    RETURNING "id", "stripe_subscription_id", "stripe_subscription_status", "user_id"
+    RETURNING *
     """,
       [
         stripeSubscription.status.rawValue,


### PR DESCRIPTION
We're getting a weird web hook failure that doesn't have any error messaging because the error is erased to `Unit`. I'm adding some more logging so that we can debug this.