### PR TITLE
Slight simplification to subscribe logic.

### DIFF
--- a/Sources/PointFree/Subscribe.swift
+++ b/Sources/PointFree/Subscribe.swift
@@ -40,36 +40,25 @@ private func subscribe(_ conn: Conn<StatusLineOpen, Tuple2<SubscribeData, User>>
     let (subscribeData, user) = conn.data
       |> lower
 
-    let subscriptionOrError = (pure(subscribeData) as EitherIO<Error, SubscribeData>)
-      .withExcept(const(unit))
-      .flatMap { subscribeData in
-        Current.stripe
-          .createCustomer(subscribeData.token, user.id.rawValue.uuidString, user.email, nil)
-          .map { ($0, subscribeData) }
-          .flatMap {
-            Current.stripe
-              .createSubscription($0.id, $1.pricing.plan, $1.pricing.quantity, $1.coupon)
+    let subscriptionOrError = Current.stripe
+      .createCustomer(subscribeData.token, user.id.rawValue.uuidString, user.email, nil)
+      .flatMap { customer in
+        Current.stripe.createSubscription(
+          customer.id,
+          subscribeData.pricing.plan,
+          subscribeData.pricing.quantity,
+          subscribeData.coupon
+        )
+      }
+      .flatMap { stripeSubscription -> EitherIO<Error, Models.Subscription?> in
+        Current.database
+          .createSubscription(stripeSubscription, user.id, subscribeData.isOwnerTakingSeat)
+          .flatMap { subscription in
+            sendInviteEmails(inviter: user, subscribeData: subscribeData)
+              .map(const(subscription))
         }
-        .flatMap { stripeSubscription -> EitherIO<Error, Models.Subscription?> in
-          let parallel = sequence(
-            subscribeData.teammates
-              .filter { email in email.rawValue.contains("@") && email != user.email }
-              .prefix(subscribeData.pricing.quantity - (subscribeData.isOwnerTakingSeat ? 1 : 0))
-              .map { email in
-                Current.database.insertTeamInvite(email, user.id)
-                  .flatMap { invite in sendInviteEmail(invite: invite, inviter: user) }
-                  .run
-                  .parallel
-            }
-          ).map(const(unit))
-
-          return lift(parallel.sequential).flatMap { _ in
-            Current.database
-              .createSubscription(stripeSubscription, user.id, subscribeData.isOwnerTakingSeat)
-          }
-        }
-    }
-    .run
+      }
+      .run
 
     return subscriptionOrError.flatMap(
       either(
@@ -91,6 +80,24 @@ private func subscribe(_ conn: Conn<StatusLineOpen, Tuple2<SubscribeData, User>>
         )
       )
     )
+}
+
+private func sendInviteEmails(inviter: User, subscribeData: SubscribeData) -> EitherIO<Error, Prelude.Unit> {
+  return lift(
+    sequence(
+      subscribeData.teammates
+        .filter { email in email.rawValue.contains("@") && email != inviter.email }
+        .prefix(subscribeData.pricing.quantity - (subscribeData.isOwnerTakingSeat ? 1 : 0))
+        .map { email in
+          Current.database.insertTeamInvite(email, inviter.id)
+            .flatMap { invite in sendInviteEmail(invite: invite, inviter: inviter) }
+            .run
+            .parallel
+    })
+      .sequential
+  )
+  .map(const(unit))
+  .catch(const(pure(unit)))
 }
 
 private func validateQuantity(_ pricing: Pricing) -> Bool {

--- a/Tests/PointFreeTests/__Snapshots__/SubscribeTests/testHappyPath_Team.2.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SubscribeTests/testHappyPath_Team.2.txt
@@ -1,6 +1,6 @@
 ▿ Subscription
-  ▿ id: 00000000-0000-0000-0000-000000000007
-    - rawValue: 00000000-0000-0000-0000-000000000007
+  ▿ id: 00000000-0000-0000-0000-000000000003
+    - rawValue: 00000000-0000-0000-0000-000000000003
   ▿ stripeSubscriptionId: sub_test
     - rawValue: "sub_test"
   - stripeSubscriptionStatus: Status.active

--- a/Tests/PointFreeTests/__Snapshots__/SubscribeTests/testHappyPath_Team_OwnerIsNotTakingSeat.2.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SubscribeTests/testHappyPath_Team_OwnerIsNotTakingSeat.2.txt
@@ -1,6 +1,6 @@
 ▿ Subscription
-  ▿ id: 00000000-0000-0000-0000-000000000008
-    - rawValue: 00000000-0000-0000-0000-000000000008
+  ▿ id: 00000000-0000-0000-0000-000000000003
+    - rawValue: 00000000-0000-0000-0000-000000000003
   ▿ stripeSubscriptionId: sub_test
     - rawValue: "sub_test"
   - stripeSubscriptionStatus: Status.active


### PR DESCRIPTION
While working on the subscribe stuff for #498 I was seeing that the subscribe middleware could be slightly simplified. First, it could be flattened by not starting off with a pure `EitherIO` value. Then, I believe we should first create the subscription in the DB and _then_ try sending out the invites. Otherwise an error in sending emails will mess up creating the DB row. Also, I think sending the invites shouldn't result result in any errors, i.e. if an email fails to send it shouldn't cause any errors to show. 