### PR TITLE
(Deployment) Precautions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,12 @@ deploy-local:
 	@heroku container:release web -a pointfreeco-local
 
 deploy-production:
+	@git fetch origin
+	@test "$$(git status --porcelain)" = "" \
+		|| (echo "  🛑 Can't deploy while the working tree is dirty" && exit 1)
+	@test "$$(git rev-parse @)" = "$$(git rev-parse origin/master)" \
+		&& test "$$(git rev-parse --abbrev-ref HEAD)" = "master" \
+		|| (echo "  🛑 Must deploy from an up-to-date origin/master" && exit 1)
 	@heroku container:login
 	@heroku container:push web -a pointfreeco
 	@heroku container:release web -a pointfreeco


### PR DESCRIPTION
Leaving out an override (for now), since we can merely run the Heroku commands from scratch if we really need to. This will blow up on `make deploy-production` if the working directory is dirty (with tracked or untracked changes), or if local `master` and `origin/master` are not in sync.