### PR TITLE
Bare minimum to support Xcode 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.0"
 
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Package.resolved
 .ssl/*
 Sources/Models/Transcripts
 bin/*
+.swiftpm/


### PR DESCRIPTION
I just wanted to do the bare minimum to get Xcode 11 support in. I'm not deleting the Xcode project or anything. It would be great to figure out how to continue using playgrounds. Even if SwiftUI previews can help us eventually, there's still some good use cases for playgrounds (like playing with the database or router).