### PR TITLE
Cmark fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
     fi
   - sudo apt-get install cmake
   - git clone https://github.com/commonmark/cmark
+  - cd cmark
   - git checkout 1880e6535e335f143f9547494def01c13f2f331b
   - make -C cmark INSTALL_PREFIX=/usr
   - sudo make -C cmark install

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - git clone https://github.com/commonmark/cmark
   - cd cmark
   - git checkout 1880e6535e335f143f9547494def01c13f2f331b
+  - cd ../
   - make -C cmark INSTALL_PREFIX=/usr
   - sudo make -C cmark install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
     fi
   - sudo apt-get install cmake
   - git clone https://github.com/commonmark/cmark
+  - git checkout 1880e6535e335f143f9547494def01c13f2f331b
   - make -C cmark INSTALL_PREFIX=/usr
   - sudo make -C cmark install
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ COPY Sources ./Sources
 COPY Tests ./Tests
 
 # cmark
-RUN git clone https://github.com/commonmark/cmark
+RUN git clone https://github.com/commonmark/cmark && \
+	cd cmark && \
+	git checkout 1880e6535e335f143f9547494def01c13f2f331b
 RUN make -C cmark INSTALL_PREFIX=/usr
 RUN make -C cmark install
 


### PR DESCRIPTION
This commit https://github.com/commonmark/cmark/pull/319 on cmark today seems to have broken our builds. Not entirely sure why yet, but a quick fix is to use cmark from the previous commit.