### PR TITLE
Speed up a bunch of test compilation times.

### DIFF
--- a/Sources/PointFree/Session.swift
+++ b/Sources/PointFree/Session.swift
@@ -18,7 +18,7 @@ private let cookieExpirationDuration: TimeInterval = 315_360_000 // 60 * 60 * 24
 public func writeSessionCookieMiddleware<A>(_ update: @escaping (Session) -> Session)
   -> (Conn<HeadersOpen, A>)
   -> IO<Conn<HeadersOpen, A>> {
-    
+
     return { conn in
       let value = update(conn.request.session)
       guard value != conn.request.session else { return pure(conn) }

--- a/Sources/PointFree/Session.swift
+++ b/Sources/PointFree/Session.swift
@@ -13,23 +13,24 @@ public enum CookieTransform: String, Codable {
   case encrypted
 }
 
+private let cookieExpirationDuration: TimeInterval = 315_360_000 // 60 * 60 * 24 * 365 * 10
+
 public func writeSessionCookieMiddleware<A>(_ update: @escaping (Session) -> Session)
   -> (Conn<HeadersOpen, A>)
   -> IO<Conn<HeadersOpen, A>> {
-
+    
     return { conn in
       let value = update(conn.request.session)
       guard value != conn.request.session else { return pure(conn) }
-      return setCookie(
-          key: pointFreeUserSessionCookieName,
-          value: value,
-          options: [
-            .expires(Current.date().addingTimeInterval(60 * 60 * 24 * 365 * 10)),
-            .path("/")
-        ]
-        )
-        .map { conn |> writeHeader($0) }
-        ?? pure(conn)
+      guard let header = setCookie(
+        key: pointFreeUserSessionCookieName,
+        value: value,
+        options: [
+          .expires(Current.date().addingTimeInterval(cookieExpirationDuration)),
+          .path("/")
+      ]) else { return pure(conn) }
+      
+      return writeHeader(header)(conn)
     }
 }
 

--- a/Tests/PointFreeTests/AccountTests/AccountTests.swift
+++ b/Tests/PointFreeTests/AccountTests/AccountTests.swift
@@ -153,16 +153,13 @@ final class AccountTests: TestCase {
   }
 
   func testAccount_WithExtraInvoiceInfo() {
+    var customer = Stripe.Customer.mock
+    customer.metadata = ["extraInvoiceInfo": "VAT: 1234567890"]
+    var subscription = Stripe.Subscription.mock
+    subscription.customer = .right(customer)
+
     Current = .teamYearly
-      |> \.stripe.fetchSubscription .~ const(
-        pure(
-          .mock
-            |> \.customer .~ .right(
-              .mock
-                |> \.metadata .~ ["extraInvoiceInfo": "VAT: 1234567890"]
-          )
-        )
-    )
+    Current.stripe.fetchSubscription = const(pure(subscription))
 
     let conn = connection(from: request(to: .account(.index), session: .loggedIn))
 

--- a/Tests/PointFreeTests/AccountTests/AccountTests.swift
+++ b/Tests/PointFreeTests/AccountTests/AccountTests.swift
@@ -240,11 +240,11 @@ final class AccountTests: TestCase {
   }
 
   func testAccountWithPastDue() {
-    update(
-      &Current,
-      \.database.fetchSubscriptionById .~ const(pure(.mock |> \.stripeSubscriptionStatus .~ .pastDue)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(.mock |> \.stripeSubscriptionStatus .~ .pastDue))
-    )
+    var subscription = Models.Subscription.mock
+    subscription.stripeSubscriptionStatus = .pastDue
+
+    Current.database.fetchSubscriptionById = const(pure(subscription))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(subscription))
 
     let conn = connection(from: request(to: .account(.index), session: .loggedIn))
 

--- a/Tests/PointFreeTests/AuthTests.swift
+++ b/Tests/PointFreeTests/AuthTests.swift
@@ -17,16 +17,13 @@ class AuthTests: TestCase {
   }
 
   func testRegister() {
-    let gitHubUserEnvelope = GitHubUserEnvelope.mock
-      |> \.accessToken .~ .init(accessToken: "1234-deadbeef")
-      |> \.gitHubUser.id .~ 1234567890
-      |> \.gitHubUser.name .~ "Blobby McBlob"
+    var gitHubUserEnvelope = GitHubUserEnvelope.mock
+    gitHubUserEnvelope.accessToken = .init(accessToken: "1234-deadbeef")
+    gitHubUserEnvelope.gitHubUser.id = 1234567890
+    gitHubUserEnvelope.gitHubUser.name = "Blobby McBlob"
 
-    update(
-      &Current,
-      \.gitHub.fetchUser .~ const(pure(gitHubUserEnvelope.gitHubUser)),
-      \.gitHub.fetchAuthToken .~ const(pure(pure(gitHubUserEnvelope.accessToken)))
-    )
+    Current.gitHub.fetchUser = const(pure(gitHubUserEnvelope.gitHubUser))
+    Current.gitHub.fetchAuthToken = const(pure(pure(gitHubUserEnvelope.accessToken)))
 
     let result = connection(
       from: request(to: .gitHubCallback(code: "deabeef", redirect: "/"), session: .loggedOut)

--- a/Tests/PointFreeTests/DiscountsTests.swift
+++ b/Tests/PointFreeTests/DiscountsTests.swift
@@ -57,12 +57,9 @@ class DiscountsTests: TestCase {
       rate: .percentOff(50),
       valid: true
     )
-    update(
-      &Current,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.fetchCoupon .~ const(pure(fiftyPercentOffForever))
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.fetchCoupon = const(pure(fiftyPercentOffForever))
 
     assertSnapshot(
       matching: connection(
@@ -99,12 +96,9 @@ class DiscountsTests: TestCase {
       rate: .amountOff(5_00),
       valid: true
     )
-    update(
-      &Current,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.fetchCoupon .~ const(pure(fiftyPercentOffForever))
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.fetchCoupon = const(pure(fiftyPercentOffForever))
 
     assertSnapshot(
       matching: connection(
@@ -123,12 +117,9 @@ class DiscountsTests: TestCase {
       rate: .percentOff(50),
       valid: true
     )
-    update(
-      &Current,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.fetchCoupon .~ const(pure(fiftyPercentOffForever))
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.fetchCoupon = const(pure(fiftyPercentOffForever))
 
     assertSnapshot(
       matching: connection(
@@ -147,12 +138,9 @@ class DiscountsTests: TestCase {
       rate: .amountOff(5_00),
       valid: true
     )
-    update(
-      &Current,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.fetchCoupon .~ const(pure(fiftyPercentOffForever))
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.fetchCoupon = const(pure(fiftyPercentOffForever))
 
     assertSnapshot(
       matching: connection(
@@ -171,12 +159,9 @@ class DiscountsTests: TestCase {
       rate: .percentOff(50),
       valid: true
     )
-    update(
-      &Current,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.fetchCoupon .~ const(pure(fiftyPercentOffForever))
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.fetchCoupon = const(pure(fiftyPercentOffForever))
 
     assertSnapshot(
       matching: connection(
@@ -195,12 +180,9 @@ class DiscountsTests: TestCase {
       rate: .amountOff(5_00),
       valid: true
     )
-    update(
-      &Current,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.fetchCoupon .~ const(pure(fiftyPercentOffForever))
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.fetchCoupon = const(pure(fiftyPercentOffForever))
 
     assertSnapshot(
       matching: connection(

--- a/Tests/PointFreeTests/EnterpriseTests.swift
+++ b/Tests/PointFreeTests/EnterpriseTests.swift
@@ -94,6 +94,7 @@ class EnterpriseTests: TestCase {
     loggedInUser.id = userId
     loggedInUser.subscriptionId = nil
 
+    Current.database = .mock
     Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
     Current.database.fetchSubscriptionById = const(pure(nil))
 
@@ -114,6 +115,7 @@ class EnterpriseTests: TestCase {
     loggedInUser.id = userId
     loggedInUser.subscriptionId = nil
 
+    Current.database = .mock
     Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
     Current.database.fetchSubscriptionById = const(pure(nil))
 
@@ -134,7 +136,8 @@ class EnterpriseTests: TestCase {
     var loggedInUser = User.mock
     loggedInUser.id = userId
     loggedInUser.subscriptionId = nil
-    
+
+    Current.database = .mock
     Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
     Current.database.fetchSubscriptionById = const(pure(nil))
     
@@ -155,6 +158,7 @@ class EnterpriseTests: TestCase {
     let loggedInUser = User.mock
       |> \.id .~ User.Id(rawValue: UUID(uuidString: "DEADBEEF-0000-0000-0000-123456789012")!)
 
+    Current.database = .mock
     Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
     Current.database.fetchSubscriptionById = const(pure(nil))
 
@@ -196,7 +200,8 @@ class EnterpriseTests: TestCase {
     let loggedInUser = User.mock
       |> \.id .~ userId
       |> \.subscriptionId .~ nil
-    
+
+    Current.database = .mock
     Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
     Current.database.fetchSubscriptionById = const(pure(nil))
 

--- a/Tests/PointFreeTests/EnterpriseTests.swift
+++ b/Tests/PointFreeTests/EnterpriseTests.swift
@@ -86,17 +86,16 @@ class EnterpriseTests: TestCase {
   }
 
   func testAccceptInvitation_BadEmail() {
-    let account = EnterpriseAccount.mock
-      |> \.domain .~ "pointfree.co"
+    var account = EnterpriseAccount.mock
+    account.domain = "pointfree.co"
     let userId = User.Id(rawValue: UUID(uuidString: "00000000-0000-0000-0000-123456789012")!)
     let encryptedUserId = Encrypted(userId.rawValue.uuidString, with: Current.envVars.appSecret)!
-    let loggedInUser = User.mock
-      |> \.id .~ userId
-      |> \.subscriptionId .~ nil
+    var loggedInUser = User.mock
+    loggedInUser.id = userId
+    loggedInUser.subscriptionId = nil
 
-    Current.database = .mock
-      |> \.fetchEnterpriseAccountForDomain .~ const(pure(.some(account)))
-      |> \.fetchSubscriptionById .~ const(pure(nil))
+    Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
+    Current.database.fetchSubscriptionById = const(pure(nil))
 
     let req = request(
       to: .enterprise(.acceptInvite(account.domain, email: "baddata", userId: encryptedUserId)),
@@ -107,17 +106,16 @@ class EnterpriseTests: TestCase {
   }
 
   func testAccceptInvitation_BadUserId() {
-    let account = EnterpriseAccount.mock
-      |> \.domain .~ "pointfree.co"
+    var account = EnterpriseAccount.mock
+    account.domain = "pointfree.co"
     let encryptedEmail = Encrypted("blob@pointfree.co", with: Current.envVars.appSecret)!
     let userId = User.Id(rawValue: UUID(uuidString: "00000000-0000-0000-0000-123456789012")!)
-    let loggedInUser = User.mock
-      |> \.id .~ userId
-      |> \.subscriptionId .~ nil
+    var loggedInUser = User.mock
+    loggedInUser.id = userId
+    loggedInUser.subscriptionId = nil
 
-    Current.database = .mock
-      |> \.fetchEnterpriseAccountForDomain .~ const(pure(.some(account)))
-      |> \.fetchSubscriptionById .~ const(pure(nil))
+    Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
+    Current.database.fetchSubscriptionById = const(pure(nil))
 
     let req = request(
       to: .enterprise(.acceptInvite(account.domain, email: encryptedEmail, userId: "baddata")),
@@ -128,19 +126,18 @@ class EnterpriseTests: TestCase {
   }
 
   func testAccceptInvitation_EmailDoesntMatchEnterpriseDomain() {
-    let account = EnterpriseAccount.mock
-      |> \.domain .~ "pointfree.co"
+    var account = EnterpriseAccount.mock
+    account.domain = "pointfree.co"
     let encryptedEmail = Encrypted("blob@pointfree.biz", with: Current.envVars.appSecret)!
     let userId = User.Id(rawValue: UUID(uuidString: "00000000-0000-0000-0000-123456789012")!)
     let encryptedUserId = Encrypted(userId.rawValue.uuidString, with: Current.envVars.appSecret)!
-    let loggedInUser = User.mock
-      |> \.id .~ userId
-      |> \.subscriptionId .~ nil
-
-    Current.database = .mock
-      |> \.fetchEnterpriseAccountForDomain .~ const(pure(.some(account)))
-      |> \.fetchSubscriptionById .~ const(pure(nil))
-
+    var loggedInUser = User.mock
+    loggedInUser.id = userId
+    loggedInUser.subscriptionId = nil
+    
+    Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    
     let req = request(
       to: .enterprise(.acceptInvite(account.domain, email: encryptedEmail, userId: encryptedUserId)),
       session: .loggedIn(as: loggedInUser)
@@ -158,9 +155,8 @@ class EnterpriseTests: TestCase {
     let loggedInUser = User.mock
       |> \.id .~ User.Id(rawValue: UUID(uuidString: "DEADBEEF-0000-0000-0000-123456789012")!)
 
-    Current.database = .mock
-      |> \.fetchEnterpriseAccountForDomain .~ const(pure(.some(account)))
-      |> \.fetchSubscriptionById .~ const(pure(nil))
+    Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
+    Current.database.fetchSubscriptionById = const(pure(nil))
 
     let req = request(
       to: .enterprise(.acceptInvite(account.domain, email: encryptedEmail, userId: encryptedUserId)),
@@ -200,10 +196,9 @@ class EnterpriseTests: TestCase {
     let loggedInUser = User.mock
       |> \.id .~ userId
       |> \.subscriptionId .~ nil
-
-    Current.database = .mock
-      |> \.fetchEnterpriseAccountForDomain .~ const(pure(.some(account)))
-      |> \.fetchSubscriptionById .~ const(pure(nil))
+    
+    Current.database.fetchEnterpriseAccountForDomain = const(pure(.some(account)))
+    Current.database.fetchSubscriptionById = const(pure(nil))
 
     let req = request(
       to: .enterprise(.acceptInvite(account.domain, email: encryptedEmail, userId: encryptedUserId)),

--- a/Tests/PointFreeTests/InviteTests.swift
+++ b/Tests/PointFreeTests/InviteTests.swift
@@ -43,18 +43,15 @@ class InviteTests: TestCase {
   }
 
   func testShowInvite_LoggedIn_NonSubscriber() {
-    let currentUser = Models.User.mock
-      |> \.id .~ .init(rawValue: UUID(uuidString: "deadbeef-dead-beef-dead-beefdead0002")!)
+    var currentUser = Models.User.mock
+    currentUser.id = .init(rawValue: UUID(uuidString: "deadbeef-dead-beef-dead-beefdead0002")!)
 
-    let invite = Models.TeamInvite.mock
-      |> \.inviterUserId .~ .init(rawValue: UUID(uuidString: "deadbeef-dead-beef-dead-beefdead0001")!)
+    var invite = Models.TeamInvite.mock
+    invite.inviterUserId = .init(rawValue: UUID(uuidString: "deadbeef-dead-beef-dead-beefdead0001")!)
 
-    let db = Database.Client.mock
-      |> (\Database.Client.fetchUserById) .~ const(pure(.some(currentUser)))
-      |> \.fetchTeamInvite .~ const(pure(.some(invite)))
-      |> \.fetchSubscriptionById .~ const(pure(nil))
-
-    update(&Current, \.database .~ db)
+    Current.database.fetchUserById = const(pure(.some(currentUser)))
+    Current.database.fetchTeamInvite = const(pure(.some(invite)))
+    Current.database.fetchSubscriptionById = const(pure(nil))
 
     let showInvite = request(to: .invite(.show(invite.id)), session: .loggedIn)
     let conn = connection(from: showInvite)

--- a/Tests/PointFreeTests/PricingLandingTests.swift
+++ b/Tests/PointFreeTests/PricingLandingTests.swift
@@ -20,12 +20,9 @@ class PricingLandingTests: TestCase {
   }
 
   func testLanding_LoggedIn_ActiveSubscriber() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.admin)),
-      \.database.fetchSubscriptionById .~ const(pure(.mock)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(.mock))
-    )
+    Current.database.fetchUserById = const(pure(.admin))
+    Current.database.fetchSubscriptionById = const(pure(.mock))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(.mock))
 
     let conn = connection(from: request(to: .pricingLanding, session: .loggedIn))
     let result = conn |> siteMiddleware

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -21,6 +21,7 @@ class PrivateRssTests: TestCase {
   func testFeed_Authenticated_Subscriber_Monthly() {
     let user = Models.User.mock
 
+    Current.database = .mock
     Current.database.fetchUserById = const(pure(.some(user)))
     Current.episodes = unzurry([introduction, ep1, ep2, ep3, ep10, ep22])
     Current.stripe.fetchSubscription = const(pure(.individualMonthly))
@@ -40,7 +41,8 @@ class PrivateRssTests: TestCase {
 
   func testFeed_Authenticated_Subscriber_Yearly() {
     let user = Models.User.mock
-
+    
+    Current.database = .mock
     Current.database.fetchUserById = const(pure(.some(user)))
     Current.episodes = unzurry([introduction, ep1, ep2, ep3, ep10, ep22])
     Current.stripe.fetchSubscription = const(pure(.individualYearly))

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -41,7 +41,7 @@ class PrivateRssTests: TestCase {
 
   func testFeed_Authenticated_Subscriber_Yearly() {
     let user = Models.User.mock
-    
+
     Current.database = .mock
     Current.database.fetchUserById = const(pure(.some(user)))
     Current.episodes = unzurry([introduction, ep1, ep2, ep3, ep10, ep22])
@@ -88,6 +88,7 @@ class PrivateRssTests: TestCase {
     var subscription = Models.Subscription.mock
     subscription.stripeSubscriptionStatus = .pastDue
 
+    Current.database = .mock
     Current.database.fetchUserById = const(pure(.some(user)))
     Current.database.fetchSubscriptionByOwnerId = const(pure(subscription))
 
@@ -129,6 +130,7 @@ class PrivateRssTests: TestCase {
   func testFeed_InvalidUserAgent() {
     let user = Models.User.mock
 
+    Current.database = .mock
     Current.database.fetchUserById = const(pure(.some(user)))
     Current.envVars.rssUserAgentWatchlist = ["blob"]
     Current.episodes = unzurry([introduction, ep1, ep2, ep3, ep10, ep22])

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -21,13 +21,9 @@ class PrivateRssTests: TestCase {
   func testFeed_Authenticated_Subscriber_Monthly() {
     let user = Models.User.mock
 
-    update(
-      &Current,
-      \.database .~ .mock,
-      \.database.fetchUserById .~ const(pure(.some(user))),
-      \.episodes .~ unzurry([introduction, ep1, ep2, ep3, ep10, ep22]),
-      \.stripe.fetchSubscription .~ const(pure(.individualMonthly))
-    )
+    Current.database.fetchUserById = const(pure(.some(user)))
+    Current.episodes = unzurry([introduction, ep1, ep2, ep3, ep10, ep22])
+    Current.stripe.fetchSubscription = const(pure(.individualMonthly))
 
     let userId = Encrypted(user.id.rawValue.uuidString, with: Current.envVars.appSecret)!
     let rssSalt = Encrypted(user.rssSalt.rawValue.uuidString, with: Current.envVars.appSecret)!
@@ -45,13 +41,9 @@ class PrivateRssTests: TestCase {
   func testFeed_Authenticated_Subscriber_Yearly() {
     let user = Models.User.mock
 
-    update(
-      &Current,
-      \.database .~ .mock,
-      \.database.fetchUserById .~ const(pure(.some(user))),
-      \.episodes .~ unzurry([introduction, ep1, ep2, ep3, ep10, ep22]),
-      \.stripe.fetchSubscription .~ const(pure(.individualYearly))
-    )
+    Current.database.fetchUserById = const(pure(.some(user)))
+    Current.episodes = unzurry([introduction, ep1, ep2, ep3, ep10, ep22])
+    Current.stripe.fetchSubscription = const(pure(.individualYearly))
 
     let userId = Encrypted(user.id.rawValue.uuidString, with: Current.envVars.appSecret)!
     let rssSalt = Encrypted(user.rssSalt.rawValue.uuidString, with: Current.envVars.appSecret)!
@@ -91,13 +83,11 @@ class PrivateRssTests: TestCase {
 
   func testFeed_Authenticated_InActiveSubscriber() {
     let user = Models.User.nonSubscriber
+    var subscription = Models.Subscription.mock
+    subscription.stripeSubscriptionStatus = .pastDue
 
-    update(
-      &Current,
-      \.database .~ .mock,
-      \.database.fetchUserById .~ const(pure(.some(user))),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(.mock |> \.stripeSubscriptionStatus .~ .pastDue))
-    )
+    Current.database.fetchUserById = const(pure(.some(user)))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(subscription))
 
     let userId = Encrypted(user.id.rawValue.uuidString, with: Current.envVars.appSecret)!
     let rssSalt = Encrypted(user.rssSalt.rawValue.uuidString, with: Current.envVars.appSecret)!

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -137,14 +137,10 @@ class PrivateRssTests: TestCase {
   func testFeed_InvalidUserAgent() {
     let user = Models.User.mock
 
-    update(
-      &Current,
-      \.database .~ .mock,
-      \.database.fetchUserById .~ const(pure(.some(user))),
-      \.envVars.rssUserAgentWatchlist .~ ["blob"],
-      \.episodes .~ unzurry([introduction, ep1, ep2, ep3, ep10, ep22]),
-      \.stripe.fetchSubscription .~ const(pure(.individualMonthly))
-    )
+    Current.database.fetchUserById = const(pure(.some(user)))
+    Current.envVars.rssUserAgentWatchlist = ["blob"]
+    Current.episodes = unzurry([introduction, ep1, ep2, ep3, ep10, ep22])
+    Current.stripe.fetchSubscription = const(pure(.individualMonthly))
 
     let userId = Encrypted(user.id.rawValue.uuidString, with: Current.envVars.appSecret)!
     let rssSalt = Encrypted(user.rssSalt.rawValue.uuidString, with: Current.envVars.appSecret)!

--- a/Tests/PointFreeTests/SubscribeConfirmationTests.swift
+++ b/Tests/PointFreeTests/SubscribeConfirmationTests.swift
@@ -20,12 +20,9 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testPersonal_LoggedIn() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    Current.database.fetchUserById = const(pure(.mock))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -56,12 +53,9 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testPersonal_LoggedIn_SwitchToMonthly() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    Current.database.fetchUserById = const(pure(.mock))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -92,12 +86,12 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testTeam_LoggedIn() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock |> \.gitHubUserId .~ -1)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    var user = User.mock
+    user.gitHubUserId = -1
+
+    Current.database.fetchUserById = const(pure(user))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -128,12 +122,12 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testTeam_LoggedIn_WithDefaults() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock |> \.gitHubUserId .~ -1)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    var user = User.mock
+    user.gitHubUserId = -1
+
+    Current.database.fetchUserById = const(pure(user))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -164,12 +158,12 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testTeam_LoggedIn_WithDefaults_OwnerIsNotTakingSeat() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock |> \.gitHubUserId .~ -1)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    var user = User.mock
+    user.gitHubUserId = -1
+
+    Current.database.fetchUserById = const(pure(user))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -200,12 +194,12 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testTeam_LoggedIn_SwitchToMonthly() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock |> \.gitHubUserId .~ -1)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    var user = User.mock
+    user.gitHubUserId = -1
+
+    Current.database.fetchUserById = const(pure(user))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -236,12 +230,12 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testTeam_LoggedIn_AddTeamMember() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock |> \.gitHubUserId .~ -1)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    var user = User.mock
+    user.gitHubUserId = 1
+
+    Current.database.fetchUserById = const(pure(user))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -272,12 +266,9 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testPersonal_LoggedIn_ActiveSubscriber() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock)),
-      \.database.fetchSubscriptionById .~ const(pure(.mock)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(.mock))
-    )
+    Current.database.fetchUserById = const(pure(.mock))
+    Current.database.fetchSubscriptionById = const(pure(.mock))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(.mock))
 
     let conn = connection(
       from: request(
@@ -296,12 +287,9 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testPersonal_LoggedOut() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(nil)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    Current.database.fetchUserById = const(pure(nil))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(
@@ -332,12 +320,9 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testPersonal_LoggedIn_WithDiscount() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    Current.database.fetchUserById = const(pure(.mock))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(from: request(to: .discounts(code: "dead-beef", nil), session: .loggedIn))
     let result = conn |> siteMiddleware
@@ -358,12 +343,12 @@ class SubscriptionConfirmationTests: TestCase {
   }
 
   func testTeam_LoggedIn_RemoveOwnerFromTeam() {
-    update(
-      &Current,
-      \.database.fetchUserById .~ const(pure(.mock |> \.gitHubUserId .~ -1)),
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil))
-    )
+    var user = User.mock
+    user.gitHubUserId = 1
+
+    Current.database.fetchUserById = const(pure(user))
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
 
     let conn = connection(
       from: request(

--- a/Tests/PointFreeTests/SubscribeTests.swift
+++ b/Tests/PointFreeTests/SubscribeTests.swift
@@ -303,13 +303,9 @@ final class SubscribeTests: TestCase {
   }
 
   func testCreateCustomerFailure() {
-    update(
-      &Current,
-      \.database .~ .mock,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.createCustomer .~ { _, _, _, _ in throwE(unit as Error) }
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.createCustomer = { _, _, _, _ in throwE(unit as Error) }
 
     let conn = connection(
       from: request(to: .subscribe(.some(.individualMonthly)), session: .loggedIn)

--- a/Tests/PointFreeTests/SubscribeTests.swift
+++ b/Tests/PointFreeTests/SubscribeTests.swift
@@ -61,6 +61,7 @@ final class SubscribeTests: TestCase {
   }
 
   func testCouponFailure_Individual() {
+    Current.database = .mock
     Current.database.fetchSubscriptionById = const(pure(nil))
     Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
     Current.stripe.createSubscription = { _, _, _, _ in throwE(StripeErrorEnvelope.mock as Error) }
@@ -303,6 +304,7 @@ final class SubscribeTests: TestCase {
   }
 
   func testCreateCustomerFailure() {
+    Current.database = .mock
     Current.database.fetchSubscriptionById = const(pure(nil))
     Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
     Current.stripe.createCustomer = { _, _, _, _ in throwE(unit as Error) }

--- a/Tests/PointFreeTests/SubscribeTests.swift
+++ b/Tests/PointFreeTests/SubscribeTests.swift
@@ -61,13 +61,9 @@ final class SubscribeTests: TestCase {
   }
 
   func testCouponFailure_Individual() {
-    update(
-      &Current,
-      \.database .~ .mock,
-      \.database.fetchSubscriptionById .~ const(pure(nil)),
-      \.database.fetchSubscriptionByOwnerId .~ const(pure(nil)),
-      \.stripe.createSubscription .~ { _, _, _, _ in throwE(StripeErrorEnvelope.mock as Error) }
-    )
+    Current.database.fetchSubscriptionById = const(pure(nil))
+    Current.database.fetchSubscriptionByOwnerId = const(pure(nil))
+    Current.stripe.createSubscription = { _, _, _, _ in throwE(StripeErrorEnvelope.mock as Error) }
 
     let subscribeData = SubscribeData.individualMonthly
       |> \.coupon .~ "deadbeef"


### PR DESCRIPTION
(NB: This is based off of #559)

Just like middlewares, some tests take awhile to build do to the way we configure the environment. This flattens things to just use plain mutation. Some things are messier this way. It would be worth seeing if we can regain the ergonomics by using overture while still keeping compile times down.