### PR TITLE
Require Episode Trailers

### DIFF
--- a/Sources/Models/Episode.swift
+++ b/Sources/Models/Episode.swift
@@ -15,7 +15,7 @@ public struct Episode {
   public var references: [Reference] = []
   public var sequence: Sequence
   public var title: String
-  public var trailerVideo: Video?
+  public var trailerVideo: Video
   public var transcriptBlocks: [TranscriptBlock]
 
   public init(
@@ -32,7 +32,7 @@ public struct Episode {
     references: [Reference] = [],
     sequence: Sequence,
     title: String,
-    trailerVideo: Video?,
+    trailerVideo: Video,
     transcriptBlocks: [TranscriptBlock]
   ) {
     self.blurb = blurb

--- a/Sources/Models/PublicEpisodes/0000-Introduction.swift
+++ b/Sources/Models/PublicEpisodes/0000-Introduction.swift
@@ -21,7 +21,12 @@ Take a moment to hear from the hosts about what to expect from this new series.
     publishedAt: Date(timeIntervalSince1970: 1_517_206_269),
     sequence: 0,
     title: "We launched!",
-    trailerVideo: nil,
+    // NB: Same as full video
+    trailerVideo: .init(
+      bytesLength: 90533615,
+      downloadUrl: "https://player.vimeo.com/external/354215017.hd.mp4?s=5ec513cdfcccb5bab74356a156dea1dabdd48a16&profile_id=175&download=1",
+      streamingSource: "https://player.vimeo.com/video/354215017"
+    ),
     transcriptBlocks: _transcriptBlocks
   )
 }

--- a/Sources/Models/PublicEpisodes/0001-Functions.swift
+++ b/Sources/Models/PublicEpisodes/0001-Functions.swift
@@ -20,7 +20,12 @@ Our first episode is all about functions! We talk a bit about what makes functio
     publishedAt: Date(timeIntervalSince1970: 1_517_206_269),
     sequence: 1,
     title: "Functions",
-    trailerVideo: nil,
+    // NB: Same as full video
+    trailerVideo: .init(
+      bytesLength: 197667168,
+      downloadUrl: "https://player.vimeo.com/external/348650932.hd.mp4?s=b448ad4d2af97f1bf3223363bd4ad34aecbb188f&profile_id=175&download=1",
+      streamingSource: "https://player.vimeo.com/video/348650932"
+    ),
     transcriptBlocks: _transcriptBlocks
   )
 }

--- a/Sources/Models/PublicEpisodes/0002-SideEffects.swift
+++ b/Sources/Models/PublicEpisodes/0002-SideEffects.swift
@@ -8,7 +8,7 @@ Side effects: can’t live with ’em; can’t write a program without ’em. Le
     codeSampleDirectory: "0002-side-effects",
     exercises: [],
     fullVideo: .init(
-      bytesLength: 238_376_744,
+      bytesLength: 238376744,
       downloadUrl: "https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&profile_id=174&download=1",
       streamingSource: "https://player.vimeo.com/video/355115445"
     ),
@@ -20,7 +20,11 @@ Side effects: can’t live with ’em; can’t write a program without ’em. Le
     publishedAt: Date(timeIntervalSince1970: 1_517_811_069),
     sequence: 2,
     title: "Side Effects",
-    trailerVideo: nil,
+    trailerVideo: .init(
+      bytesLength: 24127308,
+      downloadUrl: "https://player.vimeo.com/external/354214906.hd.mp4?s=b61f1f35996367def8924fd056ea19c23c328283&profile_id=175&download=1",
+      streamingSource: "https://player.vimeo.com/video/354214906"
+    ),
     transcriptBlocks: _transcriptBlocks
   )
 }

--- a/Sources/Models/PublicEpisodes/0003-StylingWithFunctions.swift
+++ b/Sources/Models/PublicEpisodes/0003-StylingWithFunctions.swift
@@ -17,10 +17,14 @@ We bring tools from previous episodes down to earth and apply them to an everyda
     length: 1_634,
     permission: .free,
     previousEpisodeInCollection: nil,
-    publishedAt: Date(timeIntervalSince1970: 1_518_441_151),
+    publishedAt: Date(timeIntervalSince1970: 1518441151),
     sequence: 3,
     title: "UIKit Styling with Functions",
-    trailerVideo: nil,
+    trailerVideo: .init(
+      bytesLength: 37767144,
+      downloadUrl: "https://player.vimeo.com/external/354215006.hd.mp4?s=b21ff531c35d0ab9c3147bd57d49a1aab0be3afc&profile_id=175&download=1",
+      streamingSource: "https://player.vimeo.com/video/354215006"
+    ),
     transcriptBlocks: _transcriptBlocks
   )
 }

--- a/Sources/Models/PublicEpisodes/0004-AlgebraicDataTypes.swift
+++ b/Sources/Models/PublicEpisodes/0004-AlgebraicDataTypes.swift
@@ -9,7 +9,7 @@ and see how it can help us create type-safe data structures that can catch runti
     codeSampleDirectory: "0004-algebraic-data-types",
     exercises: _exercises,
     fullVideo: .init(
-      bytesLength: 194_777_227,
+      bytesLength: 194777227,
       downloadUrl: "https://player.vimeo.com/external/355115428.hd.mp4?s=03abd49a24efede55881a7cb120e5c6b498a5ad6&profile_id=174&download=1",
       streamingSource: "https://player.vimeo.com/video/355115428"
     ),
@@ -18,13 +18,17 @@ and see how it can help us create type-safe data structures that can catch runti
     length: 2_172,
     permission: .free,
     previousEpisodeInCollection: nil,
-    publishedAt: Date(timeIntervalSince1970: 1_519_045_951),
+    publishedAt: Date(timeIntervalSince1970: 1519045951),
     references: [
       .makingIllegalStatesUnrepresentable
     ],
     sequence: 4,
     title: "Algebraic Data Types",
-    trailerVideo: nil,
+    trailerVideo: .init(
+      bytesLength: 37267895,
+      downloadUrl: "https://player.vimeo.com/external/354215001.hd.mp4?s=6ac370d37126a11c69c2c69bc0ab05f9cb47c47b&profile_id=175&download=1",
+      streamingSource: "https://player.vimeo.com/video/354215001"
+    ),
     transcriptBlocks: _transcriptBlocks
   )
 }

--- a/Sources/Models/PublicEpisodes/0010-ATaleOfTwoFlatMaps.swift
+++ b/Sources/Models/PublicEpisodes/0010-ATaleOfTwoFlatMaps.swift
@@ -23,7 +23,11 @@ operation to other structures and derive new, useful code!
     references: [.introduceSequenceCompactMap],
     sequence: 10,
     title: "A Tale of Two Flat-Maps",
-    trailerVideo: nil,
+    trailerVideo: .init(
+      bytesLength: 25231039,
+      downloadUrl: "https://player.vimeo.com/external/354214922.hd.mp4?s=6f5b0a253609ca99df375ff0526ab26cd2e30ba3&profile_id=175&download=1",
+      streamingSource: "https://player.vimeo.com/video/354214922"
+    ),
     transcriptBlocks: _transcriptBlocks
   )
 }

--- a/Sources/Models/PublicEpisodes/0029-DSL-vs-TemplatingLanguages.swift
+++ b/Sources/Models/PublicEpisodes/0029-DSL-vs-TemplatingLanguages.swift
@@ -24,7 +24,11 @@ previously hidden.
     references: [.openSourcingSwiftHtml],
     sequence: 29,
     title: "DSLs vs. Templating Languages",
-    trailerVideo: nil,
+    trailerVideo: .init(
+      bytesLength: 47720856,
+      downloadUrl: "https://player.vimeo.com/external/351396562.hd.mp4?s=ab321eebc13700128d0b9659b45dc8f8fc9fe3f2&profile_id=175&download=1",
+      streamingSource: "https://player.vimeo.com/video/351396562"
+    ),
     transcriptBlocks: _transcriptBlocks
   )
 }

--- a/Sources/PointFree/ApiMiddleware.swift
+++ b/Sources/PointFree/ApiMiddleware.swift
@@ -62,7 +62,7 @@ extension Api {
       self.title = episode.title
       self.transcriptBlocks = episode.transcriptBlocks
       self.video = subscriberOnly
-        ? episode.trailerVideo!
+        ? episode.trailerVideo
         : episode.fullVideo // TODO: use subscriber data to determine this
     }
   }

--- a/Sources/PointFree/AtomFeed.swift
+++ b/Sources/PointFree/AtomFeed.swift
@@ -125,32 +125,21 @@ can access your private podcast feed by visiting \(url(to: .account(.index))).
   }
 
   func enclosure(episode: Episode) -> RssItem.Enclosure {
-    return episode.subscriberOnly
-      ? .init(
-        length: episode.trailerVideo?.bytesLength ?? 0,
-        type: "video/mp4",
-        url: episode.trailerVideo?.downloadUrl ?? ""
-        )
-      : .init(
-        length: episode.fullVideo.bytesLength,
-        type: "video/mp4",
-        url: episode.fullVideo.downloadUrl
+    let video = episode.subscriberOnly ? episode.trailerVideo : episode.fullVideo
+    return .init(
+      length: video.bytesLength,
+      type: "video/mp4",
+      url: video.downloadUrl
     )
   }
 
   func mediaContent(episode: Episode) -> RssItem.Media.Content {
-    return episode.subscriberOnly
-      ? .init(
-        length: episode.trailerVideo?.bytesLength ?? 0,
-        medium: "video",
-        type: "video/mp4",
-        url: episode.trailerVideo?.downloadUrl ?? ""
-        )
-      : .init(
-        length: episode.fullVideo.bytesLength,
-        medium: "video",
-        type: "video/mp4",
-        url: episode.fullVideo.downloadUrl
+    let video = episode.subscriberOnly ? episode.trailerVideo : episode.fullVideo
+    return .init(
+      length: video.bytesLength,
+      medium: "video",
+      type: "video/mp4",
+      url: video.downloadUrl
     )
   }
 

--- a/Sources/Views/EpisodeVideoView.swift
+++ b/Sources/Views/EpisodeVideoView.swift
@@ -8,7 +8,7 @@ import Styleguide
 public func videoView(forEpisode episode: Episode, isEpisodeViewable: Bool) -> Node {
   let episodeSource = isEpisodeViewable
     ? episode.fullVideo.streamingSource
-    : episode.trailerVideo?.streamingSource ?? ""
+    : episode.trailerVideo.streamingSource
 
   return .div(
     attributes: [


### PR DESCRIPTION
We were only missing trailers on ep0 (which is a trailer in itself) and ep1, so I'm thinking the safest way to move non-full-video data into the main repo is to make `fullVideo` optional and cascade down to `trailerVideo` when in OSS mode.