### PR TITLE
Fix long collection names on mobile.

### DIFF
--- a/Sources/Views/Collections/CollectionSection.swift
+++ b/Sources/Views/Collections/CollectionSection.swift
@@ -282,6 +282,9 @@ private func relatedItemRow(
         ]),
       ],
       .gridRow(
+        attributes: [
+          .style(flex(wrap: .nowrap))
+        ],
         .img(
           base64: icon,
           type: .image(.svg),

--- a/Tests/PointFreeTests/__Snapshots__/CollectionsTests/testCollectionSection.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/CollectionsTests/testCollectionSection.1.Conn.txt
@@ -3,7 +3,7 @@ Authorization: Basic aGVsbG86d29ybGQ=
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 61726
+Content-Length: 61864
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2171,7 +2171,8 @@ html {
                           start-m
                           col-m
                           col-m-9">
-                <div class="row">
+                <div style="flex-wrap:nowrap"
+                     class="row">
                   <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgIDxwYXRoIGQ9Ik04IDE0LjVsNi00LjUtNi00LjV2OXpNMTAgMEM0LjQ4IDAgMCA0LjQ4IDAgMTBzNC40OCAxMCAxMCAxMCAxMC00LjQ4IDEwLTEwUzE1LjUyIDAgMTAgMHptMCAxOGMtNC40MSAwLTgtMy41OS04LThzMy41OS04IDgtOCA4IDMuNTkgOCA4LTMuNTkgOC04IDh6IiBmaWxsPSIjMTIxMjEyIi8+CiAgPC9nPgo8L3N2Zz4="
                        alt
                        class="m-pr1">
@@ -2206,7 +2207,8 @@ html {
                           start-m
                           col-m
                           col-m-9">
-                <div class="row">
+                <div style="flex-wrap:nowrap"
+                     class="row">
                   <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgIDxwYXRoIGQ9Ik04IDE0LjVsNi00LjUtNi00LjV2OXpNMTAgMEM0LjQ4IDAgMCA0LjQ4IDAgMTBzNC40OCAxMCAxMCAxMCAxMC00LjQ4IDEwLTEwUzE1LjUyIDAgMTAgMHptMCAxOGMtNC40MSAwLTgtMy41OS04LThzMy41OS04IDgtOCA4IDMuNTkgOCA4LTMuNTkgOC04IDh6IiBmaWxsPSIjMTIxMjEyIi8+CiAgPC9nPgo8L3N2Zz4="
                        alt
                        class="m-pr1">
@@ -2252,7 +2254,8 @@ html {
                           start-m
                           col-m
                           col-m-9">
-                <div class="row">
+                <div style="flex-wrap:nowrap"
+                     class="row">
                   <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgIDxwYXRoIGQ9Ik04IDE0LjVsNi00LjUtNi00LjV2OXpNMTAgMEM0LjQ4IDAgMCA0LjQ4IDAgMTBzNC40OCAxMCAxMCAxMCAxMC00LjQ4IDEwLTEwUzE1LjUyIDAgMTAgMHptMCAxOGMtNC40MSAwLTgtMy41OS04LThzMy41OS04IDgtOCA4IDMuNTkgOCA4LTMuNTkgOC04IDh6IiBmaWxsPSIjMTIxMjEyIi8+CiAgPC9nPgo8L3N2Zz4="
                        alt
                        class="m-pr1">


### PR DESCRIPTION
The simplest thing we can do to get the alignment right. I think some of the surrounding markup could be simplified too. I sketched how a basic version could look here: https://jsfiddle.net/bq3st5wL/1/

<img width="436" alt="image" src="https://user-images.githubusercontent.com/135203/76381727-7bc11000-6313-11ea-98ae-497a57aa6d3a.png">
