### PR TITLE
Make collection references lazy so that we can do cyclical references.

### DIFF
--- a/Sources/Models/Collections/Parsing.swift
+++ b/Sources/Models/Collections/Parsing.swift
@@ -1,73 +1,75 @@
 extension Episode.Collection {
-  public static let parsing = Self(
-    blurb: #"""
+  public static var parsing: Self {
+    Self(
+      blurb: #"""
 Parsing is a surprisingly ubiquitous problem in programming. Every time we construct an integer or a URL from a string, we are technically doing parsing. After demonstrating the many types of parsing that Apple gives us access to, we will take a step back and define the essence of parsing in a single type. That type supports many wonderful types of compositions, and allows us to break large, complex parsing problems into small, understandable units.
 """#,
-    sections: [
-      .init(
-        blurb: #"""
+      sections: [
+        .init(
+          blurb: #"""
 Parsing is a difficult, but surprisingly ubiquitous programming problem, and functional programming has a lot to say about it. Let's take a moment to understand the problem space of parsing, and see what tools Swift and Apple gives us to parse complex text formats.
 """#,
-        coreLessons: [
-          .init(episode: .ep56_whatIsAParser_pt1),
-          .init(episode: .ep57_whatIsAParser_pt2),
-          .init(episode: .ep58_whatIsAParser_pt3),
-        ],
-        related: [],
-        title: "What Is Parsing?",
-        whereToGoFromHere: #"""
+          coreLessons: [
+            .init(episode: .ep56_whatIsAParser_pt1),
+            .init(episode: .ep57_whatIsAParser_pt2),
+            .init(episode: .ep58_whatIsAParser_pt3),
+          ],
+          related: [],
+          title: "What Is Parsing?",
+          whereToGoFromHere: #"""
 Now that we've distilled parsing into a core, functional unit, it's time to explore its transformable, composable properties. We'll leverage [earlier learnings](/collections/map-zip-flat-map) by asking ourselves if parsers have a `map` operation, and if they have a `zip` operation, and if they have a `flatMap` operation.
 """#
-      ),
-      .init(
-        blurb: #"""
+        ),
+        .init(
+          blurb: #"""
 We'll define the functional trio of operations on the `Parser` type: `map`, `zip` and `flatMap`. They introduce a familiar means of transforming and combining simple parsers into more and more complex parsers that can extract out first class data from nebulous blobs of data.
 """#,
-        coreLessons: [
-          .init(episode: .ep59_composableParsing_map),
-          .init(episode: .ep60_composableParsing_flatMap),
-          .init(episode: .ep61_composableParsing_zip),
-        ],
-        related: [
-          .init(
-            blurb: #"""
+          coreLessons: [
+            .init(episode: .ep59_composableParsing_map),
+            .init(episode: .ep60_composableParsing_flatMap),
+            .init(episode: .ep61_composableParsing_zip),
+          ],
+          related: [
+            .init(
+              blurb: #"""
 The `Parser` type isn't the only type that supports `map`, `zip` and `flatMap` operations. There are many types that can be transformed in similar ways, and even the Swift standard library and Apple frameworks ship with many examples. This collection of episodes explores this topic deeply, and hopes to empower you to define these operations on your own types as well.
 """#,
-            content: .collection(.mapZipFlatMap)
-          )
-        ],
-        title: "Composable Parsing: Map, Zip, Flat‑Map",
-        whereToGoFromHere: #"""
+              content: .collection(.mapZipFlatMap)
+            )
+          ],
+          title: "Composable Parsing: Map, Zip, Flat‑Map",
+          whereToGoFromHere: #"""
 Now that we've seen that parsers have `map`, `zip`, and `flatMap` operations, it's time to take things to the next level and explore a whole bunch of what are commonly called "parser combinators": or "higher-order" functions that enhance and combine parsers in more and more interesting, complex ways.
 """#
-      ),
-      .init(
-        blurb: #"""
+        ),
+        .init(
+          blurb: #"""
 It's time to explore "parser combinators": functions that enhance and combine parsers in interesting ways. They will unlock some very powerful, expressive machinery and allow us to define some truly impressive parsers with little work.
 """#,
-        coreLessons: [
-          .init(episode: .ep62_parserCombinators_pt1),
-          .init(episode: .ep63_parserCombinators_pt2),
-          .init(episode: .ep64_parserCombinators_pt3),
-        ],
-        related: [
-          // TODO: bring back when we figure out recursive references
-//          .init(
-//            blurb: #"""
-//Parsing is just one of many problems functional programming solves by defining a core, composable, transformable unit. We apply these exact same techniques to randomness and even architecture!
-//"""#,
-//            content: .collections([
-//              .randomness,
-//              .composableArchitecture,
-//            ])
-//          ),
-        ],
-        title: "Parser Combinators",
-        whereToGoFromHere: #"""
+          coreLessons: [
+            .init(episode: .ep62_parserCombinators_pt1),
+            .init(episode: .ep63_parserCombinators_pt2),
+            .init(episode: .ep64_parserCombinators_pt3),
+          ],
+          related: [
+            // TODO: bring back when we figure out recursive references
+            .init(
+              blurb: #"""
+Parsing is just one of many problems functional programming solves by defining a core, composable, transformable unit. We apply these exact same techniques to randomness and even architecture!
+"""#,
+              content: .collections([
+                .randomness,
+                .composableArchitecture,
+              ])
+            ),
+          ],
+          title: "Parser Combinators",
+          whereToGoFromHere: #"""
 The parsing journey isn't over yet! We'll have more to come in future episodes. Till then, the same story has played out in our collections on [randomness](/collections/randomness) and [application architecture](/collections/composable-architecture), where we define a core type to express a certain domain and then explore all of the kinds of composition that type supports.
 """#
-      ),
-    ],
-    title: "Parsing"
-  )
+        ),
+      ],
+      title: "Parsing"
+    )
+  }
 }

--- a/Sources/Models/Episode.swift
+++ b/Sources/Models/Episode.swift
@@ -213,7 +213,18 @@ public struct Episode: Equatable {
             .collections([collection()])
           }
 
-          public static func == (lhs: Content, rhs: Content) -> Bool { return true }
+          public static func == (lhs: Content, rhs: Content) -> Bool {
+            switch (lhs, rhs) {
+            case let (.episodes(lhs), .episodes(rhs)):
+              return lhs() == rhs()
+            case let (.collections(lhs), .collections(rhs)):
+              return lhs() == rhs()
+            case let (.section(lhs, lhsIdx), .section(rhs, rhsIdx)):
+              return lhs() == rhs() && lhsIdx == rhsIdx
+            case (_, .episodes), (_, .collections), (_, .section):
+              return false
+            }
+          }
         }
       }
 

--- a/Sources/Models/Episode.swift
+++ b/Sources/Models/Episode.swift
@@ -201,17 +201,19 @@ public struct Episode: Equatable {
         }
 
         public enum Content: Equatable {
-          case episodes([Episode])
-          case collections([Collection])
-          case section(Collection, index: Int)
+          case episodes(@autoclosure () -> [Episode])
+          case collections(@autoclosure () -> [Collection])
+          case section(@autoclosure () -> Collection, index: Int)
 
-          public static func episode(_ episode: Episode) -> Content {
-            .episodes([episode])
+          public static func episode(_ episode: @escaping @autoclosure() -> Episode) -> Content {
+            .episodes([episode()])
           }
 
-          public static func collection(_ collection: Collection) -> Content {
-            .collections([collection])
+          public static func collection(_ collection: @escaping @autoclosure() -> Collection) -> Content {
+            .collections([collection()])
           }
+
+          public static func == (lhs: Content, rhs: Content) -> Bool { return true }
         }
       }
 

--- a/Sources/Views/Collections/CollectionSection.swift
+++ b/Sources/Views/Collections/CollectionSection.swift
@@ -220,7 +220,7 @@ private func relatedItem(_ relatedItem: Episode.Collection.Section.Related) -> N
 private func relatedItemContent(_ content: Episode.Collection.Section.Related.Content) -> Node {
   switch content {
   case let .collections(collections):
-    return .fragment(collections.map { collection in
+    return .fragment(collections().map { collection in
       relatedItemRow(
         icon: collectionIconSvgBase64,
         title: collection.title,
@@ -229,7 +229,7 @@ private func relatedItemContent(_ content: Episode.Collection.Section.Related.Co
       )
     })
   case let .episodes(episodes):
-    return .fragment(episodes.map { episode in
+    return .fragment(episodes().map { episode in
       relatedItemRow(
         icon: playIconSvgBase64(),
         title: episode.fullTitle,
@@ -238,6 +238,7 @@ private func relatedItemContent(_ content: Episode.Collection.Section.Related.Co
       )
     })
   case let .section(collection, index):
+    let collection = collection()
     let section = collection.sections[index]
     return relatedItemRow(
       icon: collectionIconSvgBase64,

--- a/Tests/ModelsTests/CollectionTests.swift
+++ b/Tests/ModelsTests/CollectionTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import Models
+
+final class CollectionTests: XCTestCase {
+  func testAllCollections() {
+    XCTAssertEqual(Episode.Collection.all, Episode.Collection.all)
+  }
+}


### PR DESCRIPTION
I was able to figure out the cyclical references in our collections. We needed to make the related content lazy _and_ we need to make the parsing collection a computed `var` instead of a `let`.

That causes a bunch of whitespace differences so you may want to view this diff without whitespace.