### PR TITLE
Remove email delay.

### DIFF
--- a/Sources/PointFree/Admin/NewEpisodes.swift
+++ b/Sources/PointFree/Admin/NewEpisodes.swift
@@ -112,7 +112,6 @@ private func sendEmail(
           unsubscribeData: (user.id, .newEpisode),
           content: inj2(nodes)
           )
-          .delay(.milliseconds(200))
           .retry(maxRetries: 3, backoff: { .seconds(10 * $0) })
     }
   }


### PR DESCRIPTION
This will speed things up a bit. We could speed it up a bit more if we ran a few in parallel rather than one after the other. I thought there were rate limits, but it doesn't seem like that's the case anymore, or maybe it never was...