### PR TITLE
Re-work #99.2’s solution to compile.

### DIFF
--- a/Sources/Models/Episodes/0099-ErgonomicStateManagementPt2.swift
+++ b/Sources/Models/Episodes/0099-ErgonomicStateManagementPt2.swift
@@ -91,7 +91,11 @@ extension Reducer {
         localAction,
         environment(globalEnvironment)
       )
-      .map { toLocalAction.embed((index, $0)) }
+      .map { effect in
+        effect
+          .map { action.embed((index, $0)) }
+          .eraseToEffect()
+      }
     }
   }
 }


### PR DESCRIPTION
Also, in session, we landed on this solution and were wondering if it’s equally as valid—or, would moving the index out as a top-level parameter cause issues for call sites?

```swift
extension Reducer {
  func indexed<GlobalValue, GlobalAction, GlobalEnvironment>(
    value: WritableKeyPath<GlobalValue, [Value]>,
    action: CasePath<GlobalAction, Action>,
    environment: @escaping (GlobalEnvironment) -> Environment,
    index: Int
  ) -> Reducer<GlobalValue, GlobalAction, GlobalEnvironment> {
    pullback(
      value: value.appending(path: \.[index]),
      action: action,
      environment: environment
    )
  }
}
```