### PR TITLE
Fix Docker for Heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=build /usr/include/cmark* /usr/include/
 COPY --from=build /usr/lib/libcmark* /usr/lib/
 COPY --from=build /build/.build/release/Server /usr/bin
 COPY --from=build /build/.build/release/Runner /usr/bin
-ENTRYPOINT ["Server"]
+CMD Server

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -5,7 +5,8 @@ RUN apt-get install -y cmake libpq-dev libssl-dev libz-dev openssl
 
 WORKDIR /build
 
-Copy Makefile .
+COPY .pf-env* ./
+COPY Makefile .
 COPY Package.swift .
 COPY Sources ./Sources
 COPY Tests ./Tests
@@ -18,4 +19,4 @@ RUN make -C cmark install
 
 RUN swift build --build-tests --enable-pubgrub-resolver --enable-test-discovery --jobs 1 -Xswiftc -D -Xswiftc OSS
 
-ENTRYPOINT [".build/debug/Server"]
+CMD .build/debug/Server

--- a/Sources/PointFree/RunnerTasks/WelcomeEmails.swift
+++ b/Sources/PointFree/RunnerTasks/WelcomeEmails.swift
@@ -34,13 +34,7 @@ public func sendWelcomeEmails() -> EitherIO<Error, Prelude.Unit> {
     >>> retry(maxRetries: 3, backoff: { .seconds(10 * $0) })
 
   return emails
-    .flatMap(
-      map { email in
-        delayedSend(email).map(const(email))
-          .debug { "📧: Sent welcome email to \($0)" }
-        }
-        >>> sequence
-  )
+    .flatMap(map { email in delayedSend(email).map(const(email)) } >>> sequence)
     .flatMap { (emails: [Email]) -> EitherIO<Error, SendEmailResponse> in
       let stats = emails
         .reduce(into: [String: [EmailAddress]]()) { dict, email in


### PR DESCRIPTION
TIL Heroku schedulers will run the entrypoint of a Dockerfile, which will take precedence over the command it was configured with.