### PR TITLE
Make Video model aware of vimeo id and secret.

### DIFF
--- a/Sources/Models/Episode.swift
+++ b/Sources/Models/Episode.swift
@@ -364,8 +364,15 @@ public struct Episode: Equatable {
   public struct Video: Codable, Equatable {
     // TODO: Tagged<Bytes, Int>?
     public var bytesLength: Int
-    public var downloadUrl: String
-    public var streamingSource: String
+    public var vimeoId: Int
+    public var vimeoSecret: String
+
+    public var downloadUrl: String {
+      "https://player.vimeo.com/external/\(self.vimeoId).hd.mp4?s=\(self.vimeoSecret)&profile_id=175&download=1"
+    }
+    public var streamingSource: String {
+      "https://player.vimeo.com/video/\(self.vimeoId)"
+    }
 
     public init(
       bytesLength: Int,
@@ -373,8 +380,20 @@ public struct Episode: Equatable {
       streamingSource: String
     ) {
       self.bytesLength = bytesLength
-      self.downloadUrl = downloadUrl
-      self.streamingSource = streamingSource
+      self.vimeoId = Int(streamingSource.split(separator: "/").last!)!
+      self.vimeoSecret = String(
+        downloadUrl.components(separatedBy: ".hd.mp4?s=")[1].split(separator: "&")[0]
+      )
+    }
+
+    public init(
+      bytesLength: Int,
+      vimeoId: Int,
+      vimeoSecret: String
+    ) {
+      self.bytesLength = bytesLength
+      self.vimeoId = vimeoId
+      self.vimeoSecret = vimeoSecret
     }
   }
 }

--- a/Sources/Models/Episodes/0100-ATourOfTheComposableArchitecturePt1.swift
+++ b/Sources/Models/Episodes/0100-ATourOfTheComposableArchitecturePt1.swift
@@ -9,8 +9,8 @@ It's our 100th episode 🎉! To celebrate, we are finally releasing the Composab
     exercises: _exercises,
     fullVideo: .init(
       bytesLength: 402161784,
-      downloadUrl: "https://player.vimeo.com/external/414016119.hd.mp4?s=2859c821cb22e295fb771d60b979b4f9039e8bab&profile_id=175&download=1",
-      streamingSource: "https://player.vimeo.com/video/414016119"
+      vimeoId: 414016119,
+      vimeoSecret: "2859c821cb22e295fb771d60b979b4f9039e8bab"
     ),
     id: 100,
     image: "https://i.vimeocdn.com/video/887735650.jpg",
@@ -34,9 +34,9 @@ The Composable Architecture was designed over the course of nearly 9 months of e
     subtitle: nil,
     title: "A Tour of the Composable Architecture: Part 1",
     trailerVideo: .init(
-      bytesLength: 127800813,
-      downloadUrl: "https://player.vimeo.com/external/414015638.hd.mp4?s=0adee8e9d00f457d1afbcb1189d391e88ca76f4f&profile_id=175&download=1",
-      streamingSource: "https://player.vimeo.com/video/414015638"
+      bytesLength: 402161784,
+      vimeoId: 414015638,
+      vimeoSecret: "0adee8e9d00f457d1afbcb1189d391e88ca76f4f"
     ),
     transcriptBlocks: _transcriptBlocks
   )

--- a/Sources/ModelsTestSupport/MockEpisode.swift
+++ b/Sources/ModelsTestSupport/MockEpisode.swift
@@ -168,11 +168,7 @@ As server-side Swift becomes more popular and widely adopted, it will be importa
 """,
   codeSampleDirectory: "ep1-type-safe-html",
   exercises: [.mock],
-  fullVideo: .init(
-    bytesLength: 500_000_000,
-    downloadUrl: "https://www.vimeo.com/pointfreeco/download-video.mp4",
-    streamingSource: "https://www.vimeo.com/pointfreeco/stream-video.m3u8"
-  ),
+  fullVideo: Episode.mock.fullVideo,
   id: 1,
   image: "",
   length: 1380,
@@ -181,11 +177,7 @@ As server-side Swift becomes more popular and widely adopted, it will be importa
   publishedAt: Date(timeIntervalSince1970: 1_497_960_000),
   sequence: 1,
   title: "Type-Safe HTML in Swift",
-  trailerVideo: .init(
-    bytesLength: 5_000_000,
-    downloadUrl: "https://www.vimeo.com/pointfreeco/download-trailer.mp4",
-    streamingSource: "https://www.vimeo.com/pointfreeco/stream-trailer.m3u8"
-  ),
+  trailerVideo: Episode.mock.trailerVideo,
   transcriptBlocks: [
     Episode.TranscriptBlock(
       content: """

--- a/Sources/ModelsTestSupport/MockEpisode.swift
+++ b/Sources/ModelsTestSupport/MockEpisode.swift
@@ -39,8 +39,8 @@ private let subscriberOnlyEpisode = Episode(
   exercises: [.mock],
   fullVideo: .init(
     bytesLength: 500_000_000,
-    downloadUrl: "https://www.vimeo.com/pointfreeco/download-video.mp4",
-    streamingSource: "https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+    downloadUrl: "https://www.vimeo.com/pointfreeco/download-video.hd.mp4?s=deadbeef&id=1",
+    streamingSource: "https://www.vimeo.com/pointfreeco/1234567890"
   ),
   id: 2,
   image: "",

--- a/Tests/PointFreeTests/__Snapshots__/ApiTests/testEpisode.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/ApiTests/testEpisode.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/api/episodes/1
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 8261
+Content-Length: 8158
 Content-Type: application/json
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -210,7 +210,7 @@ X-XSS-Protection: 1; mode=block
   ],
   "video" : {
     "bytesLength" : 500000000,
-    "downloadUrl" : "https:\/\/www.vimeo.com\/pointfreeco\/download-video.mp4",
-    "streamingSource" : "https:\/\/www.vimeo.com\/pointfreeco\/stream-video.m3u8"
+    "vimeoId" : 1234567890,
+    "vimeoSecret" : "deadbeef"
   }
 }

--- a/Tests/PointFreeTests/__Snapshots__/AtomFeedTests/testAtomFeed.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/AtomFeedTests/testAtomFeed.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/feed/atom.xml
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 7424
+Content-Length: 7588
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -138,11 +138,11 @@ As server-side Swift becomes more popular and widely adopted, it will be importa
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <enclosure url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                  length="500000000"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <media:content url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                      length="500000000"
                      type="video/mp4"
                      medium="video">
@@ -209,11 +209,11 @@ text, no markdown allowed. Here is some more text just to have some filler.
       <itunes:episodeType>
         trailer
       </itunes:episodeType>
-      <enclosure url="https://www.vimeo.com/pointfreeco/download-trailer.mp4"
+      <enclosure url="https://player.vimeo.com/external/123456.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                  length="5000000"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://www.vimeo.com/pointfreeco/download-trailer.mp4"
+      <media:content url="https://player.vimeo.com/external/123456.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                      length="5000000"
                      type="video/mp4"
                      medium="video">

--- a/Tests/PointFreeTests/__Snapshots__/AtomFeedTests/testEpisodeFeed.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/AtomFeedTests/testEpisodeFeed.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/feed/episodes.xml
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 7424
+Content-Length: 7588
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -138,11 +138,11 @@ As server-side Swift becomes more popular and widely adopted, it will be importa
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <enclosure url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                  length="500000000"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <media:content url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                      length="500000000"
                      type="video/mp4"
                      medium="video">
@@ -209,11 +209,11 @@ text, no markdown allowed. Here is some more text just to have some filler.
       <itunes:episodeType>
         trailer
       </itunes:episodeType>
-      <enclosure url="https://www.vimeo.com/pointfreeco/download-trailer.mp4"
+      <enclosure url="https://player.vimeo.com/external/123456.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                  length="5000000"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://www.vimeo.com/pointfreeco/download-trailer.mp4"
+      <media:content url="https://player.vimeo.com/external/123456.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                      length="5000000"
                      type="video/mp4"
                      medium="video">

--- a/Tests/PointFreeTests/__Snapshots__/AtomFeedTests/testEpisodeFeed_WithRecentlyFreeEpisode.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/AtomFeedTests/testEpisodeFeed_WithRecentlyFreeEpisode.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/feed/episodes.xml
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 7544
+Content-Length: 7720
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -141,11 +141,11 @@ text, no markdown allowed. Here is some more text just to have some filler.
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <enclosure url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                  length="500000000"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <media:content url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                      length="500000000"
                      type="video/mp4"
                      medium="video">
@@ -209,11 +209,11 @@ As server-side Swift becomes more popular and widely adopted, it will be importa
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <enclosure url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                  length="500000000"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://www.vimeo.com/pointfreeco/download-video.mp4"
+      <media:content url="https://player.vimeo.com/external/1234567890.hd.mp4?s=deadbeef&amp;profile_id=175&amp;download=1"
                      length="500000000"
                      type="video/mp4"
                      medium="video">

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_HasCredits.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_HasCredits.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 74490
+Content-Length: 74474
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2024,7 +2024,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-trailer.m3u8"
+                    src="https://player.vimeo.com/video/123456"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_NoCredits.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_NoCredits.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 75496
+Content-Length: 75480
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2024,7 +2024,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-trailer.m3u8"
+                    src="https://player.vimeo.com/video/123456"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_UsedCredit.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_UsedCredit.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 90183
+Content-Length: 90173
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2020,7 +2020,7 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PublicEpisode_NonSubscriber_UsedCredit.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PublicEpisode_NonSubscriber_UsedCredit.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 90180
+Content-Length: 90170
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2020,7 +2020,7 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-proof-in-functions
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 83060
+Content-Length: 83044
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2045,7 +2045,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-trailer.m3u8"
+                    src="https://player.vimeo.com/video/123456"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 77564
+Content-Length: 77554
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2017,7 +2017,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_ExercisesAndReferences.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_ExercisesAndReferences.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 69430
+Content-Length: 69420
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2017,7 +2017,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/collections/functions/functions-that-begin-with-a/ep2-
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 83098
+Content-Length: 83082
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2070,7 +2070,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-trailer.m3u8"
+                    src="https://player.vimeo.com/video/123456"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext_LastEpisode.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext_LastEpisode.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/collections/functions/functions-that-begin-with-a/ep1-
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 99280
+Content-Length: 99270
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2066,7 +2066,7 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_Trialing.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_Trialing.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 77564
+Content-Length: 77554
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2017,7 +2017,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_WithEpisodeProgress.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_WithEpisodeProgress.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 85299
+Content-Length: 85289
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2013,7 +2013,7 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8#t=276s"
+                    src="https://player.vimeo.com/video/1234567890#t=276s"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePage.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePage.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 85342
+Content-Length: 85332
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2045,7 +2045,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePageSubscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePageSubscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 75222
+Content-Length: 75212
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2017,7 +2017,7 @@ text, no markdown allowed. Here is some more text just to have some filler.</p>
                            w-100p
                            absolute
                            bg-gray650"
-                    src="https://www.vimeo.com/pointfreeco/stream-video.m3u8"
+                    src="https://player.vimeo.com/video/1234567890"
                     frameborder="0"
                     allow="autoplay; fullscreen"
                     allowfullscreen>

--- a/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber_Monthly.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber_Monthly.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account/rss/f9c46e50cb32c3f12369e92c8bb9d9db09edf2cce5
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 13462
+Content-Length: 13492
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -151,11 +151,11 @@ with anyone else.
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=174"
+      <enclosure url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=175&amp;download=1"
                  length="325311571"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=174"
+      <media:content url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=175&amp;download=1"
                      length="325311571"
                      type="video/mp4"
                      medium="video">
@@ -346,11 +346,11 @@ with anyone else.
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=174&amp;download=1"
+      <enclosure url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=175&amp;download=1"
                  length="238376744"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=174&amp;download=1"
+      <media:content url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=175&amp;download=1"
                      length="238376744"
                      type="video/mp4"
                      medium="video">

--- a/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber_Yearly.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber_Yearly.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account/rss/f9c46e50cb32c3f12369e92c8bb9d9db09edf2cce5
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 15845
+Content-Length: 15875
 Content-Type: text/xml; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -151,11 +151,11 @@ with anyone else.
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=174"
+      <enclosure url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=175&amp;download=1"
                  length="325311571"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=174"
+      <media:content url="https://player.vimeo.com/external/355115759.hd.mp4?s=0f54ad38cc5fd26db2c19cf457d4b427c90e55ca&amp;profile_id=175&amp;download=1"
                      length="325311571"
                      type="video/mp4"
                      medium="video">
@@ -346,11 +346,11 @@ with anyone else.
       <itunes:episodeType>
         full
       </itunes:episodeType>
-      <enclosure url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=174&amp;download=1"
+      <enclosure url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=175&amp;download=1"
                  length="238376744"
                  type="video/mp4">
       </enclosure>
-      <media:content url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=174&amp;download=1"
+      <media:content url="https://player.vimeo.com/external/355115445.hd.mp4?s=fa740bb2d49fa51b3cd6c44de1837a093f763f22&amp;profile_id=175&amp;download=1"
                      length="238376744"
                      type="video/mp4"
                      medium="video">


### PR DESCRIPTION
It's always a lil annoying to figure out the URLs for the streaming and download sources, so I've updated the `Episode.Video` model to hold the Vimeo data and the construct the url's under the hood.

For now I've made this backwards compatible so that we don't have to convert all 200+ videos now.