### PR TITLE
Remove delay from sending blog emails.

### DIFF
--- a/Sources/PointFree/Admin/SendNewBlogPostMailer.swift
+++ b/Sources/PointFree/Admin/SendNewBlogPostMailer.swift
@@ -156,7 +156,6 @@ private func sendEmail(
           unsubscribeData: (user.id, .newBlogPost),
           content: inj2(nodes)
           )
-          .delay(.milliseconds(200))
           .retry(maxRetries: 3, backoff: { .seconds(10 * $0) })
     }
   }


### PR DESCRIPTION
We removed this delay from sending new episode emails (#643) but not blog posts... 