### PR TITLE
Change blurb link to white on episode page

### DIFF
--- a/Sources/PointFree/Episode/Show.swift
+++ b/Sources/PointFree/Episode/Show.swift
@@ -37,7 +37,7 @@ let episodeResponse: M<Tuple5<Either<String, Episode.Id>, User?, SubscriberState
             subscriberState: subscriberState
           ),
           description: episode.blurb,
-          extraStyles: markdownBlockStyles,
+          extraStyles: markdownBlockStyles <> ((.id("episode-header-blurb") % (a % color(Colors.gray850)))),
           image: episode.image,
           style: .base(.minimal(.black)),
           title: "Episode #\(episode.sequence): \(episode.fullTitle)",

--- a/Sources/PointFree/Episode/Show.swift
+++ b/Sources/PointFree/Episode/Show.swift
@@ -37,7 +37,7 @@ let episodeResponse: M<Tuple5<Either<String, Episode.Id>, User?, SubscriberState
             subscriberState: subscriberState
           ),
           description: episode.blurb,
-          extraStyles: markdownBlockStyles <> ((.id("episode-header-blurb") % (a % color(Colors.gray850)))),
+          extraStyles: extraEpisodePageStyles,
           image: episode.image,
           style: .base(.minimal(.black)),
           title: "Episode #\(episode.sequence): \(episode.fullTitle)",
@@ -312,3 +312,7 @@ private func episode(forParam param: Either<String, Episode.Id>) -> Episode? {
       param.left == .some($0.slug) || param.right == .some($0.id)
     })
 }
+
+private let extraEpisodePageStyles =
+  markdownBlockStyles <>
+  .id("episode-header-blurb") % (a % color(Colors.gray850))

--- a/Sources/Views/EpisodePage.swift
+++ b/Sources/Views/EpisodePage.swift
@@ -1205,6 +1205,7 @@ private func episodeHeader(
               Class.pf.colors.fg.gray850,
               Class.pf.type.body.regular,
             ]),
+            .id("episode-header-blurb")
           ],
           .markdownBlock(episode.blurb)
         )

--- a/Tests/ModelsTests/EpisodeTests.swift
+++ b/Tests/ModelsTests/EpisodeTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import Models
 
 final class EpisodeTests: XCTestCase {
-
   func testSlug() {
     var episode = Episode.mock
     episode.id = 42

--- a/Tests/PointFreeTests/EpisodePageTests.swift
+++ b/Tests/PointFreeTests/EpisodePageTests.swift
@@ -19,7 +19,7 @@ import XCTest
 class EpisodePageIntegrationTests: LiveDatabaseTestCase {
   override func setUp() {
     super.setUp()
-    SnapshotTesting.isRecording = true
+//    SnapshotTesting.isRecording = true
   }
 
   func testRedeemEpisodeCredit_HappyPath() {
@@ -147,7 +147,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
 class EpisodePageTests: TestCase {
   override func setUp() {
     super.setUp()
-    SnapshotTesting.isRecording = true
+//    SnapshotTesting.isRecording = true
   }
 
   func testEpisodePage() {

--- a/Tests/PointFreeTests/EpisodePageTests.swift
+++ b/Tests/PointFreeTests/EpisodePageTests.swift
@@ -19,7 +19,7 @@ import XCTest
 class EpisodePageIntegrationTests: LiveDatabaseTestCase {
   override func setUp() {
     super.setUp()
-//    SnapshotTesting.record = true
+    SnapshotTesting.isRecording = true
   }
 
   func testRedeemEpisodeCredit_HappyPath() {
@@ -147,7 +147,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
 class EpisodePageTests: TestCase {
   override func setUp() {
     super.setUp()
-//    SnapshotTesting.record = true
+    SnapshotTesting.isRecording = true
   }
 
   func testEpisodePage() {

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_HasCredits.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_HasCredits.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 74470
+Content-Length: 74560
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1987,7 +1992,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_NoCredits.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_NoCredits.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 75476
+Content-Length: 75566
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1987,7 +1992,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_UsedCredit.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PrivateEpisode_NonSubscriber_UsedCredit.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 90169
+Content-Length: 90259
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1984,7 +1989,8 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.</p>
 

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PublicEpisode_NonSubscriber_UsedCredit.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodeCredit_PublicEpisode_NonSubscriber_UsedCredit.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 90166
+Content-Length: 90256
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1984,7 +1989,8 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.</p>
 

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-proof-in-functions
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 83272
+Content-Length: 83362
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -2008,7 +2013,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 77665
+Content-Length: 77755
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1980,7 +1985,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber_Deactivated.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePageSubscriber_Deactivated.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 78154
+Content-Length: 78244
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1995,7 +2000,8 @@ contact us at <a href="mailto:support@pointfree.co">support@pointfree.co</a> to 
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_ExercisesAndReferences.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_ExercisesAndReferences.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 69416
+Content-Length: 69506
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1980,7 +1985,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/collections/functions/functions-that-begin-with-a/ep2-
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 83193
+Content-Length: 83283
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -2033,7 +2038,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext_LastEpisode.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_InCollectionContext_LastEpisode.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/collections/functions/functions-that-begin-with-a/ep1-
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 99376
+Content-Length: 99466
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -2030,7 +2035,8 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.</p>
 

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_Trialing.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_Trialing.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 77665
+Content-Length: 77755
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1980,7 +1985,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_WithEpisodeProgress.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testEpisodePage_WithEpisodeProgress.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep1-type-safe-html-in-swift
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 85395
+Content-Length: 85485
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1977,7 +1982,8 @@ Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookb
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>As server-side Swift becomes more popular and widely adopted, it will be important to re-examine some of the past “best-practices” of web frameworks to see how Swift’s type system can improve upon them.</p>
 

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePage.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePage.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={}
 
 200 OK
-Content-Length: 85328
+Content-Length: 85418
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -2008,7 +2013,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>

--- a/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePageSubscriber.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EpisodePageTests/testFreeEpisodePageSubscriber.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/episodes/ep2-proof-in-functions
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 75208
+Content-Length: 75298
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -1792,6 +1792,11 @@ html {
 }
 
 
+#episode-header-blurb a {
+  color : #d8d8d8;
+}
+
+
     </style>
     <meta name="viewport"
           content="width=device-width,initial-scale=1.0">
@@ -1980,7 +1985,8 @@ text, no markdown allowed. Here is some more text just to have some filler.">
                       fg-black
                       normal
                       h5
-                      lh-4">
+                      lh-4"
+               id="episode-header-blurb">
             <div class="md-ctn">
               <p>This is a short blurb to give a high-level overview of what the episode is about. It can only be plain
 text, no markdown allowed. Here is some more text just to have some filler.</p>


### PR DESCRIPTION
I just realized that links in the blurb are rendered dark even though they are on a dark background. This is just a quick fix to make it light.
<img width="885" alt="image" src="https://user-images.githubusercontent.com/135203/107232884-cdb45f00-69d6-11eb-970b-6a2a14511610.png">
