### PR TITLE
Small typo in #139’s solutions.

### DIFF
--- a/Sources/Models/Episodes/0139-BetterTestDependencies.swift
+++ b/Sources/Models/Episodes/0139-BetterTestDependencies.swift
@@ -55,7 +55,8 @@ where
 {
   public static var failing: AnySchedulerOf<Self> {
     .failing(
-      now: .init(Date())
+      minimumTolerance: { .zero },
+      now: { .init(Date()) }
     )
   }
 }
@@ -67,7 +68,8 @@ where
 {
   public static var failing: AnySchedulerOf<Self> {
     .failing(
-      now: .init(Date())
+      minimumTolerance: { .zero },
+      now: { .init(Date()) }
     )
   }
 }


### PR DESCRIPTION
Needed the `minimumTolerance` parameter and to box `now` up into a closure. ✅