### PR TITLE
Fix regional discounts

### DIFF
--- a/Sources/Stripe/Client.swift
+++ b/Sources/Stripe/Client.swift
@@ -222,7 +222,7 @@ func createCustomer(
 -> DecodableRequest<Customer> {
 
   stripeRequest(
-    "customers",
+    "customers?expand[]=sources",
     .post(
       [
         "balance": balance?.map(String.init).rawValue,

--- a/Tests/StripeTests/StripeTests.swift
+++ b/Tests/StripeTests/StripeTests.swift
@@ -9,7 +9,7 @@ final class StripeTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    //    SnapshotTesting.record=true
+//        SnapshotTesting.isRecording=true
   }
 
   func testDecodingCustomer() throws {

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer-vat.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer-vat.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/customers
+POST https://api.stripe.com/v1/customers?expand%5B%5D=sources
 Stripe-Version: 2020-08-27
 
 balance=-1800&business_vat_id=1&description=blob&email=blob%40pointfree.co&source=tok_test

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/customers
+POST https://api.stripe.com/v1/customers?expand%5B%5D=sources
 Stripe-Version: 2020-08-27
 
 description=blob&email=blob%40pointfree.co&source=tok_test


### PR DESCRIPTION
Stripe no longer sends back a field by default, which was preventing our check from working.