### PR TITLE
Require email for teammate invite.

### DIFF
--- a/Sources/PointFreeTestSupport/TestCase.swift
+++ b/Sources/PointFreeTestSupport/TestCase.swift
@@ -16,6 +16,9 @@ open class LiveDatabaseTestCase: TestCase {
   override open func setUp() {
     super.setUp()
 
+    diffTool = "ksdiff"
+//    isRecording = true
+
     precondition(!Current.envVars.postgres.databaseUrl.rawValue.contains("amazonaws.com"))
     self.pool = EventLoopGroupConnectionPool(
       source: PostgresConnectionSource(

--- a/Sources/Views/Account/Account.swift
+++ b/Sources/Views/Account/Account.swift
@@ -1043,6 +1043,7 @@ private func addTeammateToSubscriptionRow(_ data: AccountData) -> Node {
               .name("email"),
               .placeholder("blob@example.com"),
               .type(.email),
+              .required(true),
             ]
           ),
           .input(

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithCredit.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithCredit.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 67761
+Content-Length: 67803
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2371,7 +2371,8 @@ to consume our videos: an RSS feed that can be used with podcast apps!
                                         w-100p"
                                  name="email"
                                  placeholder="blob@example.com"
-                                 type="email">
+                                 type="email"
+                                 required>
                           <input type="submit"
                                  class="medium
                                         cursor-pointer

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithFlashError.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithFlashError.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account
 Cookie: pf_session={"flash":{"message":"An error has occurred!","priority":"error"},"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 67390
+Content-Length: 67432
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 Set-Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
@@ -2367,7 +2367,8 @@ to consume our videos: an RSS feed that can be used with podcast apps!
                                         w-100p"
                                  name="email"
                                  placeholder="blob@example.com"
-                                 type="email">
+                                 type="email"
+                                 required>
                           <input type="submit"
                                  class="medium
                                         cursor-pointer

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithFlashNotice.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithFlashNotice.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account
 Cookie: pf_session={"flash":{"message":"You’ve subscribed!","priority":"notice"},"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 67390
+Content-Length: 67432
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 Set-Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
@@ -2367,7 +2367,8 @@ to consume our videos: an RSS feed that can be used with podcast apps!
                                         w-100p"
                                  name="email"
                                  placeholder="blob@example.com"
-                                 type="email">
+                                 type="email"
+                                 required>
                           <input type="submit"
                                  class="medium
                                         cursor-pointer

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithFlashWarning.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithFlashWarning.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account
 Cookie: pf_session={"flash":{"message":"Your subscription is past-due!","priority":"warning"},"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 67401
+Content-Length: 67443
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 Set-Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
@@ -2367,7 +2367,8 @@ to consume our videos: an RSS feed that can be used with podcast apps!
                                         w-100p"
                                  name="email"
                                  placeholder="blob@example.com"
-                                 type="email">
+                                 type="email"
+                                 required>
                           <input type="submit"
                                  class="medium
                                         cursor-pointer

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithPastDue.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testAccountWithPastDue.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 65631
+Content-Length: 65673
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2325,7 +2325,8 @@ Point-Free!</p>
                                         w-100p"
                                  name="email"
                                  placeholder="blob@example.com"
-                                 type="email">
+                                 type="email"
+                                 required>
                           <input type="submit"
                                  class="medium
                                         cursor-pointer

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testTeam_NoRemainingSeats.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/AccountTests/testTeam_NoRemainingSeats.1.Conn.txt
@@ -2,7 +2,7 @@ GET http://localhost:8080/account
 Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 
 200 OK
-Content-Length: 68803
+Content-Length: 68845
 Content-Type: text/html; charset=utf-8
 Referrer-Policy: strict-origin-when-cross-origin
 X-Content-Type-Options: nosniff
@@ -2386,7 +2386,8 @@ html {
                                         w-100p"
                                  name="email"
                                  placeholder="blob@example.com"
-                                 type="email">
+                                 type="email"
+                                 required>
                           <input type="submit"
                                  class="medium
                                         cursor-pointer


### PR DESCRIPTION
I realized we don't require the email for inviting a teammate which makes it easy to accidentally hit the button and get charged. Making it required gives us a little bit of validation before it is submitted.