### PR TITLE
Update subscription plan (individual → personal) of Student Discounts page

### DIFF
--- a/Sources/Models/BlogPosts/BlogPost0010_StudentDiscounts.swift
+++ b/Sources/Models/BlogPosts/BlogPost0010_StudentDiscounts.swift
@@ -9,11 +9,11 @@ public let post0010_studentDiscounts = BlogPost(
 
     .init(
       content: """
-        We're happy to announce that we now offer a 50% discount on individual subscriptions for students that are
+        We're happy to announce that we now offer a 50% discount on personal subscriptions for students that are
         currently enrolled in a university or coding school. All you have to do is
         [email us](mailto:support@pointfree.co?subject=Student%20Discount) proof of your enrollment, such as a
         scanned photo of your student ID or a proof of enrollment from the organization, and we'll give you a
-        discount code that can be used on the [individual](/pricing) subscription
+        discount code that can be used on the [personal](/pricing) subscription
         plan, both monthly and yearly.
 
         Some may think that our material isn't exactly beginner friendly, and although there is some truth to that,


### PR DESCRIPTION
On [Announcing Student Discounts](https://www.pointfree.co/blog/posts/10-announcing-student-discounts) page, it is written that a discount code for `individual` subscription plan will be given, but on [Pricing](https://www.pointfree.co/pricing) page, there's no `individual` plan.

I don't know when, but the name of the plan seems to be changed from `individual` to `personal`.
To be precise, I update the words.