### PR TITLE
Make Stripe plan description optional

### DIFF
--- a/Sources/PointFree/Account/Cancel.swift
+++ b/Sources/PointFree/Account/Cancel.swift
@@ -243,7 +243,7 @@ let cancelEmailView =
       newsletter: nil,
       title: "Your subscription has been canceled",
       preheader: """
-        Your \(subscription.plan.nickname) subscription has been canceled and will remain active through
+        Your \(subscription.plan.description) subscription has been canceled and will remain active through
         \(monthDayYearFormatter.string(from: subscription.currentPeriodEnd)).
         """,
       template: .default(),
@@ -266,7 +266,7 @@ private func cancelEmailBodyView(user: User, subscription: Stripe.Subscription) 
           .p(
             attributes: [.class([Class.padding([.mobile: [.topBottom: 2]])])],
             "Your ",
-            .strong(.text(subscription.plan.nickname)),
+            .strong(.text(subscription.plan.description)),
             " subscription has been canceled and will remain active through ",
             .text(monthDayYearFormatter.string(from: subscription.currentPeriodEnd)),
             ". If you change your mind before then, you can reactivate from ",
@@ -297,7 +297,7 @@ let reactivateEmailView =
       newsletter: nil,
       title: "Your subscription has been reactivated",
       preheader:
-        "Your \(subscription.plan.nickname) subscription has been reactivated and will renew on \(monthDayYearFormatter.string(from: subscription.currentPeriodEnd)).",
+        "Your \(subscription.plan.description) subscription has been reactivated and will renew on \(monthDayYearFormatter.string(from: subscription.currentPeriodEnd)).",
       template: .default(),
       data: (owner, subscription)
     )
@@ -318,7 +318,7 @@ private func reactivateEmailBodyView(user: User, subscription: Stripe.Subscripti
           .p(
             attributes: [.class([Class.padding([.mobile: [.topBottom: 2]])])],
             "Thanks for sticking with us! Your ",
-            .strong(.text(subscription.plan.nickname)),
+            .strong(.text(subscription.plan.description)),
             " subscription has been reactivated and will renew on ",
             .text(monthDayYearFormatter.string(from: subscription.currentPeriodEnd)),
             "."

--- a/Sources/Stripe/Model.swift
+++ b/Sources/Stripe/Model.swift
@@ -368,7 +368,7 @@ public struct Plan: Codable, Equatable {
   public var id: Id
   public var interval: Interval
   public var metadata: [String: String]
-  public var nickname: String
+  public var nickname: String?
 
   public init(
     created: Date,
@@ -376,7 +376,7 @@ public struct Plan: Codable, Equatable {
     id: Id,
     interval: Interval,
     metadata: [String: String],
-    nickname: String
+    nickname: String?
   ) {
     self.created = created
     self.currency = currency
@@ -391,6 +391,10 @@ public struct Plan: Codable, Equatable {
   public enum Interval: String, Codable {
     case month
     case year
+  }
+
+  public var description: String {
+    self.nickname ?? self.id.rawValue
   }
 }
 

--- a/Sources/Views/Account/Account.swift
+++ b/Sources/Views/Account/Account.swift
@@ -617,8 +617,8 @@ private func subscriptionTeammateOverview(_ data: AccountData) -> Node {
 
 private func planName(for subscription: Stripe.Subscription) -> String {
   return subscription.quantity > 1
-    ? subscription.plan.nickname + " (×" + String(subscription.quantity) + ")"
-    : subscription.plan.nickname
+    ? subscription.plan.description + " (×" + String(subscription.quantity) + ")"
+    : subscription.plan.description
 }
 
 public func status(for subscription: Stripe.Subscription) -> String {

--- a/Sources/Views/Account/Invoices.swift
+++ b/Sources/Views/Account/Invoices.swift
@@ -234,7 +234,7 @@ public func invoiceView(
         attributes: [.class([Class.padding([.mobile: [.bottom: 1]])])],
         .gridColumn(
           sizes: [.mobile: 6, .desktop: 6],
-          .div(.text(item.description ?? subscription.plan.nickname))
+          .div(.text(item.description ?? subscription.plan.description))
         ),
         .gridColumn(
           sizes: [.mobile: 2, .desktop: 2],


### PR DESCRIPTION
The value can be `null`, so let's be honest about it and generous about decoding.