### PR TITLE
Stripe: fall back to old sources API

### DIFF
--- a/Sources/Stripe/Model.swift
+++ b/Sources/Stripe/Model.swift
@@ -155,6 +155,7 @@ public enum Currency: String, Codable {
 public struct Customer: Codable, Equatable, Identifiable {
   public var balance: Cents<Int>
   public var businessVatId: Vat?
+  public var defaultSource: Card?
   public var id: StripeID<Self>
   public var invoiceSettings: InvoiceSettings
   public var metadata: [String: String]
@@ -162,12 +163,14 @@ public struct Customer: Codable, Equatable, Identifiable {
   public init(
     balance: Cents<Int>,
     businessVatId: Vat?,
+    defaultSource: Card?,
     id: ID,
     invoiceSettings: InvoiceSettings,
     metadata: [String: String]
   ) {
     self.balance = balance
     self.businessVatId = businessVatId
+    self.defaultSource = defaultSource
     self.id = id
     self.invoiceSettings = invoiceSettings
     self.metadata = metadata
@@ -187,6 +190,10 @@ public struct Customer: Codable, Equatable, Identifiable {
     ) {
       self.defaultPaymentMethod = defaultPaymentMethod
     }
+  }
+
+  public var hasPaymentInfo: Bool {
+    self.invoiceSettings.defaultPaymentMethod != nil || self.defaultSource != nil
   }
 }
 

--- a/Sources/StripeTestSupport/Mocks.swift
+++ b/Sources/StripeTestSupport/Mocks.swift
@@ -97,6 +97,7 @@ extension Customer {
   public static let mock = Customer(
     balance: 0,
     businessVatId: nil,
+    defaultSource: nil,
     id: "cus_test",
     invoiceSettings: .init(defaultPaymentMethod: "pm_card_test"),
     metadata: [:]

--- a/Tests/StripeTests/StripeTests.swift
+++ b/Tests/StripeTests/StripeTests.swift
@@ -11,7 +11,7 @@ final class StripeTests: TestCase {
 
   override func setUp() {
     super.setUp()
-    //        SnapshotTesting.isRecording=true
+    // SnapshotTesting.isRecording=true
   }
 
   func testDecodingCustomer() throws {
@@ -399,7 +399,7 @@ final class StripeTests: TestCase {
   }
 
   func testRequests() {
-    //SnapshotTesting.isRecording = true
+    // SnapshotTesting.isRecording = true
     assertSnapshot(
       matching: Stripe.cancelSubscription(id: "sub_test", immediately: false).rawValue,
       as: .raw,

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.cancel-subscription-immediately.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.cancel-subscription-immediately.txt
@@ -1,3 +1,3 @@
-DELETE https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer
+DELETE https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27
 

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.cancel-subscription.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.cancel-subscription.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer
+POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27
 
 cancel_at_period_end=true

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer-vat.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer-vat.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/customers?expand%5B%5D=sources
+POST https://api.stripe.com/v1/customers
 Stripe-Version: 2020-08-27
 
 balance=-1800&business_vat_id=1&description=blob&email=blob%40pointfree.co&invoice_settings[default_payment_method]=pm_tok_test&payment_method=pm_tok_test

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-customer.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/customers?expand%5B%5D=sources
+POST https://api.stripe.com/v1/customers
 Stripe-Version: 2020-08-27
 
 description=blob&email=blob%40pointfree.co&invoice_settings[default_payment_method]=pm_tok_test&payment_method=pm_tok_test

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-subscription-coupon.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-subscription-coupon.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/subscriptions?expand%5B%5D=customer
+POST https://api.stripe.com/v1/subscriptions?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27
 
 coupon=freebie&customer=cus_test&items[0][plan]=monthly-2019&items[0][quantity]=1

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-subscription.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.create-subscription.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/subscriptions?expand%5B%5D=customer
+POST https://api.stripe.com/v1/subscriptions?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27
 
 customer=cus_test&items[0][plan]=yearly-2019&items[0][quantity]=2

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.fetch-subscription.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.fetch-subscription.txt
@@ -1,2 +1,2 @@
-GET https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer
+GET https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.update-subscription-discount-preserved.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.update-subscription-discount-preserved.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer
+POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27
 
 cancel_at_period_end=false&items[0][id]=si_test&items[0][plan]=monthly-2019&items[0][quantity]=1&payment_behavior=error_if_incomplete&proration_behavior=always_invoice

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.update-subscription-discount-removed.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.update-subscription-discount-removed.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer
+POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27
 
 cancel_at_period_end=false&coupon=&items[0][id]=si_test&items[0][plan]=monthly-2019&items[0][quantity]=2&payment_behavior=error_if_incomplete&proration_behavior=always_invoice

--- a/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.update-subscription.txt
+++ b/Tests/StripeTests/__Snapshots__/StripeTests/testRequests.update-subscription.txt
@@ -1,4 +1,4 @@
-POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer
+POST https://api.stripe.com/v1/subscriptions/sub_test?expand%5B%5D=customer.default_source
 Stripe-Version: 2020-08-27
 
 cancel_at_period_end=false&items[0][id]=si_test&items[0][plan]=yearly-2019&items[0][quantity]=1&payment_behavior=error_if_incomplete&proration_behavior=always_invoice


### PR DESCRIPTION
Stripe does not populate a user's payment method from existing sources, so let's not prevent a customer from using this payment method to add seats, upgrade, or downgrade.