### PR TITLE
Try out new `Conn` helpers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -221,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-web",
       "state" : {
-        "branch" : "a33fcff",
-        "revision" : "a33fcffb1de6dc23bcb5eeb494bbc000f2a80807"
+        "branch" : "fe0e57f",
+        "revision" : "fe0e57f3c5498c6a6310053c4f7156a870897396"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -195,7 +195,7 @@
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "branch" : "async",
-        "revision" : "d6e4f82ff00bae0fc46965ef10d0391de145b884"
+        "revision" : "ba290fbfc69c5efc0589ccb279615b775dedb335"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -217,6 +217,15 @@
       }
     },
     {
+      "identity" : "swift-web",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-web",
+      "state" : {
+        "branch" : "a33fcff",
+        "revision" : "a33fcffb1de6dc23bcb5eeb494bbc000f2a80807"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/Package.resolved
+++ b/Package.resolved
@@ -217,15 +217,6 @@
       }
     },
     {
-      "identity" : "swift-web",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-web",
-      "state" : {
-        "branch" : "13db455",
-        "revision" : "13db4559945b736277ad19cee5b0d59ffeaf83d2"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/Package.swift
+++ b/Package.swift
@@ -45,8 +45,7 @@ var package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "async"),
     .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-url-routing", from: "0.1.0"),
-//    .package(url: "https://github.com/pointfreeco/swift-web", revision: "13db455"),
-    .package(path: "../swift-web"),
+    .package(url: "https://github.com/pointfreeco/swift-web", revision: "a33fcff"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.0"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ var package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "async"),
     .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-url-routing", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/swift-web", revision: "a33fcff"),
+    .package(url: "https://github.com/pointfreeco/swift-web", revision: "fe0e57f"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.0"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,8 @@ var package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "async"),
     .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-url-routing", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/swift-web", revision: "13db455"),
+//    .package(url: "https://github.com/pointfreeco/swift-web", revision: "13db455"),
+    .package(path: "../swift-web"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.0"),
   ],
   targets: [

--- a/Sources/PointFree/About.swift
+++ b/Sources/PointFree/About.swift
@@ -7,19 +7,19 @@ import Prelude
 import Tuple
 import Views
 
-let aboutResponse:
-  Middleware<StatusLineOpen, ResponseEnded, (User?, SubscriberState, SiteRoute?), Data> =
-    writeStatus(.ok)
-    >=> respond(
-      view: aboutView,
-      layoutData: { currentUser, subscriberState, currentRoute in
-        SimplePageLayoutData(
-          currentRoute: currentRoute,
-          currentSubscriberState: subscriberState,
-          currentUser: currentUser,
-          data: [.brandon, .stephen],
-          extraStyles: aboutExtraStyles,
-          title: "About"
-        )
-      }
-    )
+func aboutResponse(
+  _ conn: Conn<StatusLineOpen, (User?, SubscriberState, SiteRoute?)>
+) -> Conn<ResponseEnded, Data> {
+  conn
+    .writeStatus(.ok)
+    .respond(view: aboutView) { currentUser, subscriberState, currentRoute in
+      SimplePageLayoutData(
+        currentRoute: currentRoute,
+        currentSubscriberState: subscriberState,
+        currentUser: currentUser,
+        data: [.brandon, .stephen],
+        extraStyles: aboutExtraStyles,
+        title: "About"
+      )
+    }
+}

--- a/Sources/PointFree/Account/AccountMiddleware.swift
+++ b/Sources/PointFree/Account/AccountMiddleware.swift
@@ -41,14 +41,10 @@ func accountMiddleware(
       |> updatePaymentInfoMiddleware
 
   case let .rss(salt):
-    return conn.map(const(salt .*. unit))
-      |> accountRssMiddleware
+    return IO { await accountRssMiddleware(conn.map { _ in salt })  }
 
   case let .rssLegacy(secret1, secret2):
-    return
-      conn
-      .map(const(User.RssSalt(rawValue: "\(secret1)/\(secret2)") .*. unit))
-      |> accountRssMiddleware
+    return IO { await accountRssMiddleware(conn.map { _ in "\(secret1)/\(secret2)" })  }
 
   case .subscription(.cancel):
     return conn.map(const(user .*. unit))

--- a/Sources/PointFree/Account/AccountMiddleware.swift
+++ b/Sources/PointFree/Account/AccountMiddleware.swift
@@ -47,8 +47,7 @@ func accountMiddleware(
     return IO { await accountRssMiddleware(conn.map { _ in "\(secret1)/\(secret2)" })  }
 
   case .subscription(.cancel):
-    return conn.map(const(user .*. unit))
-      |> cancelMiddleware
+    return IO { await cancelMiddleware(conn.map { _ in user }) }
 
   case .subscription(.change(.show)):
     return conn
@@ -59,8 +58,7 @@ func accountMiddleware(
       |> subscriptionChangeMiddleware
 
   case .subscription(.reactivate):
-    return conn.map(const(user .*. unit))
-      |> reactivateMiddleware
+    return IO { await reactivateMiddleware(conn.map { _ in user }) }
 
   case let .update(data):
     return conn.map(const(user .*. data .*. unit))

--- a/Sources/PointFree/Account/PrivateRss.swift
+++ b/Sources/PointFree/Account/PrivateRss.swift
@@ -37,7 +37,7 @@ func accountRssMiddleware(
       _ = try await sendInvalidRssFeedEmail(user: user, userAgent: userAgent)
         .withExcept { $0 as Error }
         .performAsync()
-      return conn.invalidatedFeed(
+      return conn.invalidatedFeedResponse(
         errorMessage: """
           ‼️ The URL for this feed has been turned off by Point-Free due to suspicious \
           activity. You can retrieve your most up-to-date private podcast URL by visiting your \
@@ -52,7 +52,7 @@ func accountRssMiddleware(
       .fetchSubscriptionById(user.subscriptionId.unwrap())
     guard !subscription.deactivated
     else {
-      return conn.invalidatedFeed(
+      return conn.invalidatedFeedResponse(
         errorMessage: """
           ‼️ Your subscription has been deactivated. Please contact us at support@pointfree.co \
           to regain access to Point-Free.
@@ -66,7 +66,7 @@ func accountRssMiddleware(
       )
       .isActive
     else {
-      return conn.invalidatedFeed(
+      return conn.invalidatedFeedResponse(
         errorMessage: """
           ‼️ The URL for this feed has been turned off by Point-Free as the associated \
           subscription is no longer active. If you would like reactive this feed you can \
@@ -85,7 +85,7 @@ func accountRssMiddleware(
       .writeStatus(.ok)
       .respond(xml: privateEpisodesFeedView)
   } catch {
-    return conn.invalidatedFeed(
+    return conn.invalidatedFeedResponse(
       errorMessage: """
         ‼️ The URL for this feed has been turned off by Point-Free as the associated subscription \
         is no longer active. If you would like reactive this feed you can resubscribe to \
@@ -97,7 +97,7 @@ func accountRssMiddleware(
 }
 
 extension Conn where Step == StatusLineOpen {
-  fileprivate func invalidatedFeed(errorMessage: String) -> Conn<ResponseEnded, Data> {
+  fileprivate func invalidatedFeedResponse(errorMessage: String) -> Conn<ResponseEnded, Data> {
     self
       .map { _ in errorMessage }
       .writeStatus(.ok)

--- a/Sources/PointFree/AtomFeed.swift
+++ b/Sources/PointFree/AtomFeed.swift
@@ -6,12 +6,14 @@ import PointFreeRouter
 import Prelude
 import Syndication
 
-let episodesRssMiddleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
-  writeStatus(.ok)
-  >=> respond(episodesFeedView, contentType: .text(.init(rawValue: "xml"), charset: .utf8))
-  >=> clearHeadBody
+func episodesRssMiddleware(_ conn: Conn<StatusLineOpen, Void>) -> Conn<ResponseEnded, Data> {
+  conn
+    .writeStatus(.ok)
+    .respond(xml: episodesFeedView)
+    .clearBodyForHeadRequests()
+}
 
-private let episodesFeedView = itunesRssFeedLayout { (_: Prelude.Unit) in
+private let episodesFeedView = itunesRssFeedLayout {
   [
     node(
       rssChannel: freeEpisodeRssChannel,
@@ -178,6 +180,16 @@ private func item(episode: Episode) -> RssItem {
 // TODO: swift-web
 extension Html.Application {
   public static var atom = Html.Application(rawValue: "atom+xml")
+}
+
+extension Conn where Step == HeadersOpen {
+  public func respond(xml view: (A) -> Node) -> Conn<ResponseEnded, Data> {
+    self
+      .respond(
+        body: Current.renderXml(view(self.data)),
+        contentType: .text(.init(rawValue: "xml"), charset: .utf8)
+      )
+  }
 }
 
 public func respond<A>(_ view: @escaping (A) -> Node, contentType: MediaType = .html) -> Middleware<

--- a/Sources/PointFree/Auth.swift
+++ b/Sources/PointFree/Auth.swift
@@ -39,6 +39,12 @@ let logoutResponse: M<Prelude.Unit> =
     headersMiddleware: writeSessionCookieMiddleware { $0.user = nil }
   )
 
+extension Conn where Step == StatusLineOpen {
+  public func loginAndRedirect() -> Conn<ResponseEnded, Data> {
+    self.redirect(to: .login(redirect: self.request.url?.absoluteString))
+  }
+}
+
 public func loginAndRedirect<A>(_ conn: Conn<StatusLineOpen, A>) -> IO<Conn<ResponseEnded, Data>> {
   conn |> redirect(to: .login(redirect: conn.request.url?.absoluteString))
 }

--- a/Sources/PointFree/Emails/SendEmail.swift
+++ b/Sources/PointFree/Emails/SendEmail.swift
@@ -125,3 +125,20 @@ func notifyError(subject: String) -> (Error) -> Prelude.Unit {
     return unit
   }
 }
+
+func notifyError<R>(subject: String, operation: () async throws -> R) async -> R? {
+  do {
+    return try await operation()
+  } catch {
+    Task {
+      var errorDump = ""
+      dump(error, to: &errorDump)
+      _ = try await sendEmail(
+        to: adminEmails,
+        subject: "[PointFree Error] \(subject)",
+        content: inj1(errorDump)
+      )
+    }
+    return nil
+  }
+}

--- a/Sources/PointFree/Session.swift
+++ b/Sources/PointFree/Session.swift
@@ -15,15 +15,11 @@ public enum CookieTransform: String, Codable {
 
 private let cookieExpirationDuration: TimeInterval = 315_360_000  // 60 * 60 * 24 * 365 * 10
 
-public func writeSessionCookieMiddleware<A>(_ update: @escaping (inout Session) -> Void)
-  -> (Conn<HeadersOpen, A>)
-  -> IO<Conn<HeadersOpen, A>>
-{
-
-  return { conn in
-    var session = conn.request.session
+extension Conn where Step == HeadersOpen {
+  public func writeSessionCookie(_ update: @escaping (inout Session) -> Void) -> Self {
+    var session = self.request.session
     update(&session)
-    guard session != conn.request.session else { return pure(conn) }
+    guard session != self.request.session else { return self }
     guard
       let header = setCookie(
         key: pointFreeUserSessionCookieName,
@@ -31,11 +27,24 @@ public func writeSessionCookieMiddleware<A>(_ update: @escaping (inout Session) 
         options: [
           .expires(Current.date().addingTimeInterval(cookieExpirationDuration)),
           .path("/"),
-        ])
-    else { return pure(conn) }
+        ]
+      )
+    else { return self }
 
-    return writeHeader(header)(conn)
+    return self.writeHeader(header)
   }
+
+  public func flash(_ priority: Flash.Priority, _ message: String) -> Self {
+    self.writeSessionCookie { $0.flash = Flash(priority, message) }
+  }
+}
+
+public func writeSessionCookieMiddleware<A>(_ update: @escaping (inout Session) -> Void)
+  -> (Conn<HeadersOpen, A>)
+  -> IO<Conn<HeadersOpen, A>>
+{
+
+  return { conn in pure(conn.writeSessionCookie(update)) }
 }
 
 public func flash<A>(_ priority: Flash.Priority, _ message: String) -> Middleware<

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -157,12 +157,13 @@ private func render(
   case .feed(.atom), .feed(.episodes):
     guard !Current.envVars.emergencyMode
     else {
-      return conn.map(const(unit))
-        |> writeStatus(.internalServerError)
-        >=> respond(json: "{}")
+      return pure(
+        conn
+          .writeStatus(.internalServerError)
+          .respond(json: "{}")
+      )
     }
-    return conn.map(const(unit))
-      |> episodesRssMiddleware
+    return pure(episodesRssMiddleware(conn.map { _ in }))
 
   case let .gifts(giftsRoute):
     return conn.map(

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -155,15 +155,16 @@ private func render(
       |> expressUnsubscribeReplyMiddleware
 
   case .feed(.atom), .feed(.episodes):
-    guard !Current.envVars.emergencyMode
-    else {
-      return pure(
-        conn
-          .writeStatus(.internalServerError)
-          .respond(json: "{}")
+      return IO {
+        guard !Current.envVars.emergencyMode
+        else {
+          return conn
+            .writeStatus(.internalServerError)
+            .respond(json: "{}")
+        }
+        return episodesRssMiddleware(conn.map { _ in }
       )
     }
-    return pure(episodesRssMiddleware(conn.map { _ in }))
 
   case let .gifts(giftsRoute):
     return conn.map(

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -289,6 +289,48 @@ private func render(
   }
 }
 
+extension Conn where Step == StatusLineOpen {
+  public func redirect(
+    to route: SiteRoute,
+    headersMiddleware: (Conn<HeadersOpen, A>) -> Conn<HeadersOpen, A> = { $0 }
+  ) -> Conn<ResponseEnded, Data> {
+    self.redirect(
+      to: siteRouter.path(for: route),
+      headersMiddleware: headersMiddleware
+    )
+  }
+
+  public func redirect(
+    with route: (A) -> SiteRoute,
+    headersMiddleware: (Conn<HeadersOpen, A>) -> Conn<HeadersOpen, A> = { $0 }
+  ) -> Conn<ResponseEnded, Data> {
+    self.redirect(
+      to: siteRouter.path(for: route(self.data)),
+      headersMiddleware: headersMiddleware
+    )
+  }
+
+  public func redirect(
+    to route: SiteRoute,
+    headersMiddleware: (Conn<HeadersOpen, A>) async -> Conn<HeadersOpen, A> = { $0 }
+  ) async -> Conn<ResponseEnded, Data> {
+    await self.redirect(
+      to: siteRouter.path(for: route),
+      headersMiddleware: headersMiddleware
+    )
+  }
+
+  public func redirect(
+    with route: (A) -> SiteRoute,
+    headersMiddleware: (Conn<HeadersOpen, A>) async -> Conn<HeadersOpen, A> = { $0 }
+  ) async -> Conn<ResponseEnded, Data> {
+    await self.redirect(
+      to: siteRouter.path(for: route(self.data)),
+      headersMiddleware: headersMiddleware
+    )
+  }
+}
+
 public func redirect<A>(
   with route: @escaping (A) -> SiteRoute,
   headersMiddleware: @escaping Middleware<HeadersOpen, HeadersOpen, A, A> = (id >>> pure)

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -63,7 +63,7 @@ private func render(
 
   switch route {
   case .about:
-    return aboutResponse(conn.map(const((user, subscriberState, route))))
+    return pure(aboutResponse(conn.map { _ in (user, subscriberState, route) }))
 
   case let .account(account):
     return conn.map(const(subscription .*. user .*. subscriberState .*. account .*. unit))

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/CancelTests/testCancelNoSubscription.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/CancelTests/testCancelNoSubscription.1.Conn.txt
@@ -4,7 +4,7 @@ Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 302 Found
 Location: /account
 Referrer-Policy: strict-origin-when-cross-origin
-Set-Cookie: pf_session={"flash":{"message":"We were unable to locate all of your subscription information. Please contact <support@pointfree.co> and let\nus know how we can help!","priority":"error"},"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
+Set-Cookie: pf_session={"flash":{"message":"We were unable to locate all of your subscription information. Please contact <support@pointfree.co> and let us know how we can help!","priority":"error"},"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
 X-Content-Type-Options: nosniff
 X-Download-Options: noopen
 X-Frame-Options: SAMEORIGIN

--- a/Tests/PointFreeTests/AccountTests/__Snapshots__/CancelTests/testReactivateNoSubscription.1.Conn.txt
+++ b/Tests/PointFreeTests/AccountTests/__Snapshots__/CancelTests/testReactivateNoSubscription.1.Conn.txt
@@ -4,7 +4,7 @@ Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
 302 Found
 Location: /account
 Referrer-Policy: strict-origin-when-cross-origin
-Set-Cookie: pf_session={"flash":{"message":"We were unable to locate all of your subscription information. Please contact <support@pointfree.co> and let\nus know how we can help!","priority":"error"},"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
+Set-Cookie: pf_session={"flash":{"message":"We were unable to locate all of your subscription information. Please contact <support@pointfree.co> and let us know how we can help!","priority":"error"},"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
 X-Content-Type-Options: nosniff
 X-Download-Options: noopen
 X-Frame-Options: SAMEORIGIN

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -63,6 +63,23 @@ class PrivateRssTests: TestCase {
     await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
   }
 
+  func testFeed_Authenticated_Subscriber_Yearly_StripeDown() async throws {
+    var user = Models.User.mock
+    user.rssSalt = "deadbeef"
+
+    Current.database.fetchUserByRssSalt = { _ in user }
+    Current.stripe.fetchSubscription = { _ in throw unit }
+
+    let conn = connection(
+      from: request(
+        to: .account(.rss(salt: "deadbeef")),
+        session: .loggedOut
+      )
+    )
+
+    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+  }
+
   func testFeed_Authenticated_NonSubscriber() async throws {
     var user = Models.User.nonSubscriber
     user.rssSalt = "deadbeef"

--- a/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber_Yearly_StripeDown.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/PrivateRssTests/testFeed_Authenticated_Subscriber_Yearly_StripeDown.1.Conn.txt
@@ -1,0 +1,367 @@
+GET http://localhost:8080/account/rss/deadbeef
+Cookie: pf_session={}
+
+200 OK
+Content-Length: 13313
+Content-Type: text/xml; charset=utf-8
+Referrer-Policy: strict-origin-when-cross-origin
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: SAMEORIGIN
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+
+<?xml version="1.0" encoding="utf-8" ?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+     xmlns:rawvoice="http://www.rawvoice.com/rawvoiceRssModule/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:media="http://www.rssboard.org/media-rss"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     version="2.0">
+  <channel>
+    <title>
+      Point-Free Videos (Private feed for hello@pointfree.co)
+    </title>
+    <link>
+      http://localhost:8080/
+    </link>
+    <language>
+      en-US
+    </language>
+    <description>
+      Point-Free is a video series about functional programming and the Swift programming language. Each episode
+covers a topic that may seem complex and academic at first, but turns out to be quite simple. At the end of
+each episode we’ll ask “what’s the point?!”, so that we can bring the concepts back down to earth and show
+how these ideas can improve the quality of your code today.
+
+---
+
+This is a private feed associated with the Point-Free account hello@pointfree.co. Please do not share this link
+with anyone else.
+    </description>
+    <copyright>
+      Copyright Point-Free, Inc. 2018
+    </copyright>
+    <image>
+      <url>
+        https://d3rccdn33rt8ze.cloudfront.net/social-assets/pf-avatar-square.jpg
+      </url>
+      <title>
+        Point-Free Videos (Private feed for hello@pointfree.co)
+      </title>
+      <link>
+        http://localhost:8080/
+      </link>
+    </image>
+    <itunes:author>
+      Brandon Williams & Stephen Celis
+    </itunes:author>
+    <itunes:block>
+      yes
+    </itunes:block>
+    <itunes:subtitle>
+      Functional programming concepts explained simply.
+    </itunes:subtitle>
+    <itunes:summary>
+      Point-Free is a video series about functional programming and the Swift programming language. Each episode
+covers a topic that may seem complex and academic at first, but turns out to be quite simple. At the end of
+each episode we’ll ask “what’s the point?!”, so that we can bring the concepts back down to earth and show
+how these ideas can improve the quality of your code today.
+
+---
+
+This is a private feed associated with the Point-Free account hello@pointfree.co. Please do not share this link
+with anyone else.
+    </itunes:summary>
+    <itunes:explicit>
+      no
+    </itunes:explicit>
+    <itunes:owner>
+      <itunes:name>
+        Brandon Williams & Stephen Celis
+      </itunes:name>
+      <itunes:email>
+        support@pointfree.co
+      </itunes:email>
+    </itunes:owner>
+    <itunes:type>
+      episodic
+    </itunes:type>
+    <itunes:keywords>
+      programming,development,mobile,ios,functional,swift,apple,developer,software engineering,server,app
+    </itunes:keywords>
+    <itunes:image href="https://d3rccdn33rt8ze.cloudfront.net/social-assets/pf-avatar-square.jpg">
+    </itunes:image>
+    <itunes:category text="Technology">
+      <itunes:category>
+        Software How-To
+      </itunes:category>
+    </itunes:category>
+    <itunes:category text="Education">
+      <itunes:category>
+        Training
+      </itunes:category>
+    </itunes:category>
+    <item>
+      <title>
+        A Tour of Point-Free
+      </title>
+      <pubDate>
+        Mon, 16 Jul 2018 09:57:03 +0000
+      </pubDate>
+      <link>
+        http://localhost:8080/episodes/ep22-a-tour-of-point-free
+      </link>
+      <guid>
+        http://localhost:8080/episodes/ep22-a-tour-of-point-free
+      </guid>
+      <description>
+        Join us for a tour of the code base that powers this very site and see what functional programming can look like in a production code base! We'll walk through cloning the repo and getting the site running on your local machine before showing off some of the fun functional programming we do on a daily basis.
+      </description>
+      <dc:creator>
+        Brandon Williams
+      </dc:creator>
+      <dc:creator>
+        Stephen Celis
+      </dc:creator>
+      <itunes:author>
+        Brandon Williams & Stephen Celis
+      </itunes:author>
+      <itunes:subtitle>
+        Join us for a tour of the code base that powers this very site and see what functional programming can look like in a production code base! We'll walk through cloning the repo and getting the site running on your local machine before showing off some of the fun functional programming we do on a daily basis.
+      </itunes:subtitle>
+      <itunes:summary>
+        Join us for a tour of the code base that powers this very site and see what functional programming can look like in a production code base! We'll walk through cloning the repo and getting the site running on your local machine before showing off some of the fun functional programming we do on a daily basis.
+      </itunes:summary>
+      <itunes:explicit>
+        no
+      </itunes:explicit>
+      <itunes:duration>
+        00:39:21
+      </itunes:duration>
+      <itunes:image>
+        http://localhost:8080/images/22.jpg
+      </itunes:image>
+      <itunes:season>
+        1
+      </itunes:season>
+      <itunes:episode>
+        22
+      </itunes:episode>
+      <itunes:title>
+        A Tour of Point-Free
+      </itunes:title>
+      <itunes:episodeType>
+        full
+      </itunes:episodeType>
+      <enclosure url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0022-720p-8793fae0ead64a90a3c3b5853d438107.mp4"
+                 length="325311571"
+                 type="video/mp4">
+      </enclosure>
+      <media:content url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0022-720p-8793fae0ead64a90a3c3b5853d438107.mp4"
+                     length="325311571"
+                     type="video/mp4"
+                     medium="video">
+        <media:title>
+          A Tour of Point-Free
+        </media:title>
+      </media:content>
+    </item>
+    <item>
+      <title>
+        A Tale of Two Flat‑Maps
+      </title>
+      <pubDate>
+        Tue, 27 Mar 2018 09:57:03 +0000
+      </pubDate>
+      <link>
+        http://localhost:8080/episodes/ep10-a-tale-of-two-flat-maps
+      </link>
+      <guid>
+        http://localhost:8080/episodes/ep10-a-tale-of-two-flat-maps
+      </guid>
+      <description>
+        Swift 4.1 deprecated and renamed a particular overload of `flatMap`. What made this `flatMap` different from the others? We'll explore this and how understanding that difference helps us explore generalizations of the operation to other structures and derive new, useful code!
+      </description>
+      <dc:creator>
+        Brandon Williams
+      </dc:creator>
+      <dc:creator>
+        Stephen Celis
+      </dc:creator>
+      <itunes:author>
+        Brandon Williams & Stephen Celis
+      </itunes:author>
+      <itunes:subtitle>
+        Swift 4.1 deprecated and renamed a particular overload of `flatMap`. What made this `flatMap` different from the others? We'll explore this and how understanding that difference helps us explore generalizations of the operation to other structures and derive new, useful code!
+      </itunes:subtitle>
+      <itunes:summary>
+        Swift 4.1 deprecated and renamed a particular overload of `flatMap`. What made this `flatMap` different from the others? We'll explore this and how understanding that difference helps us explore generalizations of the operation to other structures and derive new, useful code!
+      </itunes:summary>
+      <itunes:explicit>
+        no
+      </itunes:explicit>
+      <itunes:duration>
+        00:25:04
+      </itunes:duration>
+      <itunes:image>
+        http://localhost:8080/images/10.jpg
+      </itunes:image>
+      <itunes:season>
+        1
+      </itunes:season>
+      <itunes:episode>
+        10
+      </itunes:episode>
+      <itunes:title>
+        A Tale of Two Flat‑Maps
+      </itunes:title>
+      <itunes:episodeType>
+        full
+      </itunes:episodeType>
+      <enclosure url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0010-720p-e9a302614ab44c4ba7199874d0865d18.mp4"
+                 length="164582242"
+                 type="video/mp4">
+      </enclosure>
+      <media:content url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0010-720p-e9a302614ab44c4ba7199874d0865d18.mp4"
+                     length="164582242"
+                     type="video/mp4"
+                     medium="video">
+        <media:title>
+          A Tale of Two Flat‑Maps
+        </media:title>
+      </media:content>
+    </item>
+    <item>
+      <title>
+        UIKit Styling with Functions
+      </title>
+      <pubDate>
+        Mon, 12 Feb 2018 13:12:31 +0000
+      </pubDate>
+      <link>
+        http://localhost:8080/episodes/ep3-uikit-styling-with-functions
+      </link>
+      <guid>
+        http://localhost:8080/episodes/ep3-uikit-styling-with-functions
+      </guid>
+      <description>
+        We bring tools from previous episodes down to earth and apply them to an everyday task: UIKit styling. Plain functions unlock worlds of composability and reusability in styling of UI components. Have we finally solved the styling problem?
+      </description>
+      <dc:creator>
+        Brandon Williams
+      </dc:creator>
+      <dc:creator>
+        Stephen Celis
+      </dc:creator>
+      <itunes:author>
+        Brandon Williams & Stephen Celis
+      </itunes:author>
+      <itunes:subtitle>
+        We bring tools from previous episodes down to earth and apply them to an everyday task: UIKit styling. Plain functions unlock worlds of composability and reusability in styling of UI components. Have we finally solved the styling problem?
+      </itunes:subtitle>
+      <itunes:summary>
+        We bring tools from previous episodes down to earth and apply them to an everyday task: UIKit styling. Plain functions unlock worlds of composability and reusability in styling of UI components. Have we finally solved the styling problem?
+      </itunes:summary>
+      <itunes:explicit>
+        no
+      </itunes:explicit>
+      <itunes:duration>
+        00:27:14
+      </itunes:duration>
+      <itunes:image>
+        http://localhost:8080/images/3.jpg
+      </itunes:image>
+      <itunes:season>
+        1
+      </itunes:season>
+      <itunes:episode>
+        3
+      </itunes:episode>
+      <itunes:title>
+        UIKit Styling with Functions
+      </itunes:title>
+      <itunes:episodeType>
+        full
+      </itunes:episodeType>
+      <enclosure url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0003-720p-db25f205768d4cbd8c6e698099e3942e.mp4"
+                 length="324873341"
+                 type="video/mp4">
+      </enclosure>
+      <media:content url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0003-720p-db25f205768d4cbd8c6e698099e3942e.mp4"
+                     length="324873341"
+                     type="video/mp4"
+                     medium="video">
+        <media:title>
+          UIKit Styling with Functions
+        </media:title>
+      </media:content>
+    </item>
+    <item>
+      <title>
+        Side Effects
+      </title>
+      <pubDate>
+        Mon, 05 Feb 2018 06:11:09 +0000
+      </pubDate>
+      <link>
+        http://localhost:8080/episodes/ep2-side-effects
+      </link>
+      <guid>
+        http://localhost:8080/episodes/ep2-side-effects
+      </guid>
+      <description>
+        Side effects: can’t live with ’em; can’t write a program without ’em. Let’s explore a few kinds of side effects we encounter every day, why they make code difficult to reason about and test, and how we can control them without losing composition.
+      </description>
+      <dc:creator>
+        Brandon Williams
+      </dc:creator>
+      <dc:creator>
+        Stephen Celis
+      </dc:creator>
+      <itunes:author>
+        Brandon Williams & Stephen Celis
+      </itunes:author>
+      <itunes:subtitle>
+        Side effects: can’t live with ’em; can’t write a program without ’em. Let’s explore a few kinds of side effects we encounter every day, why they make code difficult to reason about and test, and how we can control them without losing composition.
+      </itunes:subtitle>
+      <itunes:summary>
+        Side effects: can’t live with ’em; can’t write a program without ’em. Let’s explore a few kinds of side effects we encounter every day, why they make code difficult to reason about and test, and how we can control them without losing composition.
+      </itunes:summary>
+      <itunes:explicit>
+        no
+      </itunes:explicit>
+      <itunes:duration>
+        00:44:36
+      </itunes:duration>
+      <itunes:image>
+        http://localhost:8080/images/2.jpg
+      </itunes:image>
+      <itunes:season>
+        1
+      </itunes:season>
+      <itunes:episode>
+        2
+      </itunes:episode>
+      <itunes:title>
+        Side Effects
+      </itunes:title>
+      <itunes:episodeType>
+        full
+      </itunes:episodeType>
+      <enclosure url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0002-720p-161f2904f8a24b33b21695df3555cfae.mp4"
+                 length="238376744"
+                 type="video/mp4">
+      </enclosure>
+      <media:content url="https://pointfreeco-episodes-processed.s3.amazonaws.com/0002-720p-161f2904f8a24b33b21695df3555cfae.mp4"
+                     length="238376744"
+                     type="video/mp4"
+                     medium="video">
+        <media:title>
+          Side Effects
+        </media:title>
+      </media:content>
+    </item>
+  </channel>
+</rss>
+


### PR DESCRIPTION
I ported many of our IO middleware helpers over to `Conn` in an effort to make refactoring existing endpoints easier: https://github.com/pointfreeco/swift-web/commit/a33fcffb1de6dc23bcb5eeb494bbc000f2a80807

This PR exercises this ability to disentangle a couple endpoints: the About page (which is simple), and the private RSS endpoints (which was pretty complex).