### PR TITLE
Async siteMiddleware

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -240,7 +240,7 @@
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "branch" : "async",
-        "revision" : "ba290fbfc69c5efc0589ccb279615b775dedb335"
+        "revision" : "606a366cc0ca0104b8e5356fd2978b181c3e5e5a"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -240,7 +240,7 @@
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "branch" : "async",
-        "revision" : "606a366cc0ca0104b8e5356fd2978b181c3e5e5a"
+        "revision" : "28c1ed939b86e878f09b8b2203f5e4da91fb738d"
       }
     },
     {
@@ -266,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-web",
       "state" : {
-        "branch" : "8a72d75",
-        "revision" : "8a72d75050372cae56c953bfde6e6cf228782594"
+        "branch" : "c754f0e",
+        "revision" : "c754f0e58e559b61e2b3fdbbe250c1c195b5a72f"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ var package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "async"),
     .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.9.0"),
     .package(url: "https://github.com/pointfreeco/swift-url-routing", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/swift-web", revision: "8a72d75"),
+    .package(url: "https://github.com/pointfreeco/swift-web", revision: "c754f0e"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.0"),
   ],
   targets: [

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -14,11 +14,7 @@ import Styleguide
 import Tuple
 import Views
 
-public let siteMiddleware = { conn in
-  IO { await _siteMiddleware(conn) }
-}
-
-public func _siteMiddleware(
+public func siteMiddleware(
   _ conn: Conn<StatusLineOpen, Prelude.Unit>
 ) async -> Conn<ResponseEnded, Data> {
   @Dependency(\.database) var database
@@ -98,12 +94,11 @@ public func _siteMiddleware(
     // Early out if route cannot be matched
     guard siteRoute != nil
     else { return await routeNotFoundMiddleware(conn).performAsync() }
-
-    return await render(conn: conn).performAsync()
+    return await render(conn: conn)
   }
 }
 
-private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) -> IO<Conn<ResponseEnded, Data>> {
+private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) async -> Conn<ResponseEnded, Data> {
   @Dependency(\.currentUser) var currentUser
   @Dependency(\.currentRoute) var route
   @Dependency(\.siteRouter) var siteRouter
@@ -111,43 +106,45 @@ private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) -> IO<Conn<Respons
 
   switch route {
   case .about:
-    return pure(aboutResponse(conn.map { _ in () }))
+    return aboutResponse(conn.map { _ in () })
 
   case let .account(account):
-    return conn.map(const(account))
-      |> accountMiddleware
+    return await accountMiddleware(conn: conn.map(const(account)))
+      .performAsync()
 
   case let .admin(route):
-    return conn.map(const(route))
-      |> adminMiddleware
+    return await adminMiddleware(conn: conn.map(const(route)))
+      .performAsync()
 
   case let .api(apiRoute):
-    return conn.map(const(apiRoute))
-      |> apiMiddleware
+    return await apiMiddleware(conn.map(const(apiRoute)))
+      .performAsync()
 
   case .appleDeveloperMerchantIdDomainAssociation:
-    return conn.map(const(unit))
-      |> appleDeveloperMerchantIdDomainAssociationMiddleware
+    return await appleDeveloperMerchantIdDomainAssociationMiddleware(conn.map(const(unit)))
+      .performAsync()
 
   case let .blog(subRoute):
-    return conn.map(const(subRoute))
-      |> blogMiddleware
+    return await blogMiddleware(conn: conn.map(const(subRoute)))
+      .performAsync()
 
   case .collections(.index):
-    return conn.map(const(()))
-      |> collectionsIndexMiddleware
+    return await collectionsIndexMiddleware(conn.map(const(())))
+      .performAsync()
 
   case let .collections(.collection(slug, .show)):
-    return conn.map(const(slug))
-      |> collectionMiddleware
+    return await collectionMiddleware(conn.map(const(slug)))
+      .performAsync()
 
   case let .collections(.collection(collectionSlug, .section(sectionSlug, .show))):
-    return conn.map(const(collectionSlug .*. sectionSlug .*. unit))
-      |> collectionSectionMiddleware
+    return await collectionSectionMiddleware(
+      conn.map(const(collectionSlug .*. sectionSlug .*. unit))
+    )
+      .performAsync()
 
   case let .collections(.collection(collectionSlug, .section(_, .episode(episodeParam)))):
-    return conn.map(const(episodeParam .*. collectionSlug .*. unit))
-      |> episodeResponse
+    return await episodeResponse(conn.map(const(episodeParam .*. collectionSlug .*. unit)))
+      .performAsync()
 
   case let .discounts(couponId, billing):
     let subscribeData = SubscribeConfirmationData(
@@ -157,116 +154,114 @@ private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) -> IO<Conn<Respons
       teammates: [],
       useRegionalDiscount: false
     )
-    return conn.map(const(.personal .*. subscribeData .*. couponId .*. unit))
-      |> discountSubscribeConfirmation
+    return await discountSubscribeConfirmation(
+      conn.map(const(.personal .*. subscribeData .*. couponId .*. unit))
+    )
+    .performAsync()
 
   case .endGhosting:
-    return conn.map(const(unit))
-      |> endGhostingMiddleware
+    return await endGhostingMiddleware(conn.map(const(unit)))
+      .performAsync()
 
   case .episode(.index):
-    return conn
-      |> redirect(to: siteRouter.path(for: .home))
+    return await redirect(to: siteRouter.path(for: .home))(conn)
+      .performAsync()
 
   case let .episode(.progress(param: param, percent: percent)):
-    return conn.map(const(param .*. percent .*. unit))
-      |> progressResponse
+    return await progressResponse(conn.map(const(param .*. percent .*. unit)))
+      .performAsync()
 
   case let .episode(.show(param)):
-    return conn.map(const(param .*. nil .*. unit))
-      |> episodeResponse
+    return await episodeResponse(conn.map(const(param .*. nil .*. unit)))
+      .performAsync()
 
   case let .enterprise(domain, .acceptInvite(encryptedEmail, encryptedUserId)):
-    return conn.map(const(currentUser .*. domain .*. encryptedEmail .*. encryptedUserId .*. unit))
-      |> enterpriseAcceptInviteMiddleware
+    return await enterpriseAcceptInviteMiddleware(
+      conn.map(const(currentUser .*. domain .*. encryptedEmail .*. encryptedUserId .*. unit))
+    )
+    .performAsync()
 
   case let .enterprise(domain, .landing):
-    return conn.map(const(domain))
-      |> enterpriseLandingResponse
+    return await enterpriseLandingResponse(conn.map(const(domain)))
+      .performAsync()
 
   case let .enterprise(domain, .requestInvite(request)):
-    return conn.map(const(domain .*. request .*. unit))
-      |> enterpriseRequestMiddleware
+    return await enterpriseRequestMiddleware(conn.map(const(domain .*. request .*. unit)))
+      .performAsync()
 
   case let .expressUnsubscribe(payload):
-    return conn.map(const(payload))
-      |> expressUnsubscribeMiddleware
+    return await expressUnsubscribeMiddleware(conn.map(const(payload)))
+      .performAsync()
 
   case let .expressUnsubscribeReply(payload):
-    return conn.map(const(payload))
-      |> expressUnsubscribeReplyMiddleware
+    return await expressUnsubscribeReplyMiddleware(conn.map(const(payload)))
+      .performAsync()
 
   case .feed(.atom), .feed(.episodes):
     @Dependency(\.envVars.emergencyMode) var emergencyMode
-
-    return IO {
-      guard !emergencyMode
-      else {
-        return
-          conn
-          .writeStatus(.internalServerError)
-          .respond(json: "{}")
-      }
-      return episodesRssMiddleware(
-        conn.map { _ in }
-      )
+    guard !emergencyMode
+    else {
+      return conn
+        .writeStatus(.internalServerError)
+        .respond(json: "{}")
     }
+    return episodesRssMiddleware(conn.map { _ in })
 
   case let .gifts(giftsRoute):
-    return conn.map(const(giftsRoute))
-      |> giftsMiddleware
+    return await giftsMiddleware(conn.map(const(giftsRoute)))
+      .performAsync()
 
   case let .gitHubCallback(code, redirect):
-    return conn.map(const(code .*. redirect .*. unit))
-      |> gitHubCallbackResponse
+    return await gitHubCallbackResponse(conn.map(const(code .*. redirect .*. unit)))
+      .performAsync()
 
   case .home:
-    return conn.map(const(()))
-      |> homeMiddleware
+    return await homeMiddleware(conn.map(const(())))
+      .performAsync()
 
   case let .invite(.addTeammate(email)):
-    return conn.map(const(currentUser .*. email .*. unit))
-      |> addTeammateViaInviteMiddleware
+    return await addTeammateViaInviteMiddleware(conn.map(const(currentUser .*. email .*. unit)))
+      .performAsync()
 
   case let .invite(.invitation(inviteId, .accept)):
-    return conn.map(const(inviteId .*. currentUser .*. unit))
-      |> acceptInviteMiddleware
+    return await acceptInviteMiddleware(conn.map(const(inviteId .*. currentUser .*. unit)))
+      .performAsync()
 
   case let .invite(.invitation(inviteId, .resend)):
-    return conn.map(const(inviteId .*. currentUser .*. unit))
-      |> resendInviteMiddleware
+    return await resendInviteMiddleware(conn.map(const(inviteId .*. currentUser .*. unit)))
+      .performAsync()
 
   case let .invite(.invitation(inviteId, .revoke)):
-    return conn.map(const(inviteId .*. currentUser .*. unit))
-      |> revokeInviteMiddleware
+    return await revokeInviteMiddleware(conn.map(const(inviteId .*. currentUser .*. unit)))
+      .performAsync()
 
   case let .invite(.invitation(inviteId, .show)):
-    return conn.map(const(inviteId .*. currentUser .*. unit))
-      |> showInviteMiddleware
+    return await showInviteMiddleware(conn.map(const(inviteId .*. currentUser .*. unit)))
+      .performAsync()
 
   case let .invite(.send(email)):
-    return conn.map(const(email .*. currentUser .*. unit))
-      |> sendInviteMiddleware
+    return await sendInviteMiddleware(conn.map(const(email .*. currentUser .*. unit)))
+      .performAsync()
 
   case let .login(redirect):
-    return conn.map(const(redirect))
-      |> loginResponse
+    return await loginResponse(conn.map(const(redirect)))
+      .performAsync()
 
   case .logout:
-    return conn.map(const(unit))
-      |> logoutResponse
+    return await logoutResponse(conn.map(const(unit)))
+      .performAsync()
 
   case .pricingLanding:
-    return conn.map(const(()))
-      |> pricingLanding
+    return await pricingLanding(conn.map(const(())))
+      .performAsync()
 
   case .privacy:
-    return conn.map(const(()))
-      |> privacyResponse
+    return await privacyResponse(conn.map(const(())))
+      .performAsync()
 
   case let .subscribe(data):
-    return conn.map(const(currentUser .*. data .*. unit))
-      |> subscribeMiddleware
+    return await subscribeMiddleware(conn.map(const(currentUser .*. data .*. unit)))
+      .performAsync()
 
   case let .subscribeConfirmation(
     lane, billing, isOwnerTakingSeat, teammates, referralCode, useRegionalDiscount
@@ -279,50 +274,54 @@ private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) -> IO<Conn<Respons
       teammates: teammates,
       useRegionalDiscount: useRegionalDiscount ?? false
     )
-    return conn.map(
-      const(lane .*. subscribeData .*. nil .*. unit))
-      |> subscribeConfirmation
+    return await subscribeConfirmation(
+      conn.map(const(lane .*. subscribeData .*. nil .*. unit))
+    )
+    .performAsync()
 
   case let .team(.join(teamInviteCode, .landing)):
-    return conn.map(const(teamInviteCode))
-      |> joinTeamLandingMiddleware
+    return await joinTeamLandingMiddleware(conn.map(const(teamInviteCode)))
+      .performAsync()
 
   case let .team(.join(teamInviteCode, .confirm)):
-    return conn.map(const(teamInviteCode))
-      |> joinTeamMiddleware
+    return await joinTeamMiddleware(conn.map(const(teamInviteCode)))
+      .performAsync()
 
   case .team(.leave):
-    return conn.map(const(currentUser .*. subscriberState .*. unit))
-      |> leaveTeamMiddleware
+    return await leaveTeamMiddleware(conn.map(const(currentUser .*. subscriberState .*. unit)))
+      .performAsync()
 
   case let .team(.remove(teammateId)):
-    return conn.map(const(teammateId .*. currentUser .*. unit))
-      |> removeTeammateMiddleware
+    return await removeTeammateMiddleware(conn.map(const(teammateId .*. currentUser .*. unit)))
+      .performAsync()
 
   case let .useEpisodeCredit(episodeId):
-    return conn.map(
-      const(Either.right(episodeId) .*. currentUser .*. subscriberState .*. route .*. unit))
-      |> useCreditResponse
+    return await useCreditResponse(
+      conn: conn.map(
+        const(Either.right(episodeId) .*. currentUser .*. subscriberState .*. route .*. unit)
+      )
+    )
+    .performAsync()
 
   case let .webhooks(.stripe(.paymentIntents(event))):
-    return conn.map(const(event))
-      |> stripePaymentIntentsWebhookMiddleware
+    return await stripePaymentIntentsWebhookMiddleware(conn.map(const(event)))
+      .performAsync()
 
   case let .webhooks(.stripe(.subscriptions(event))):
-    return conn.map(const(event))
-      |> stripeSubscriptionsWebhookMiddleware
+    return await stripeSubscriptionsWebhookMiddleware(conn.map(const(event)))
+      .performAsync()
 
   case let .webhooks(.stripe(.unknown(event))):
     @Dependency(\.logger) var logger: Logger
     logger.log(.error, "Received invalid webhook \(event.type)")
     return conn
-      |> writeStatus(.internalServerError)
-      >=> respond(text: "We don't support this event.")
+      .writeStatus(.internalServerError)
+      .respond(text: "We don't support this event.")
 
   case .webhooks(.stripe(.fatal)):
     return conn
-      |> writeStatus(.internalServerError)
-      >=> respond(text: "We don't support this event.")
+      .writeStatus(.internalServerError)
+      .respond(text: "We don't support this event.")
   }
 }
 

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -18,7 +18,7 @@ public let siteMiddleware = { conn in
   IO { await _siteMiddleware(conn) }
 }
 
-private func _siteMiddleware(
+public func _siteMiddleware(
   _ conn: Conn<StatusLineOpen, Prelude.Unit>
 ) async -> Conn<ResponseEnded, Data> {
   @Dependency(\.database) var database

--- a/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
+++ b/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
@@ -84,16 +84,6 @@ extension UUID {
 }
 
 extension Snapshotting {
-  public static var ioConn: Snapshotting<IO<Conn<ResponseEnded, Data>>, String> {
-    return Snapshotting<Conn<ResponseEnded, Data>, String>.conn.pullback { io in
-      await withDependencies {
-        $0.renderHtml = { debugRender($0) }
-      } operation: {
-        await io.performAsync()
-      }
-    }
-  }
-
   #if os(macOS)
     @available(OSX 10.13, *)
     public static func connWebView(
@@ -107,27 +97,6 @@ extension Snapshotting {
               $0.renderHtml = { Html.render($0) }
             } operation: {
               conn.data
-            },
-            as: UTF8.self
-          ),
-          baseURL: nil
-        )
-        return webView
-      }
-    }
-
-    @available(OSX 10.13, *)
-    public static func ioConnWebView(size: CGSize) -> Snapshotting<
-      IO<Conn<ResponseEnded, Data>>, NSImage
-    > {
-      return Snapshotting<NSView, NSImage>.image.pullback { @MainActor io in
-        let webView = WKWebView(frame: .init(origin: .zero, size: size))
-        await webView.loadHTMLString(
-          String(
-            decoding: withDependencies {
-              $0.renderHtml = { Html.render($0) }
-            } operation: {
-              await io.performAsync().data
             },
             as: UTF8.self
           ),

--- a/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
+++ b/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
@@ -84,28 +84,31 @@ extension UUID {
 }
 
 extension Snapshotting {
-  #if os(macOS)
-    @available(OSX 10.13, *)
-    public static func connWebView(
-      size: CGSize
-    ) -> Snapshotting<Conn<ResponseEnded, Data>, NSImage> {
-      return Snapshotting<NSView, NSImage>.image.pullback { @MainActor conn in
+#if os(macOS)
+  @available(OSX 10.13, *)
+  public static func connWebView(
+    size: CGSize
+  ) -> Snapshotting<Conn<ResponseEnded, Data>, NSImage> {
+    var snapshotting = Snapshotting<NSView, NSImage>.image
+      .pullback { @MainActor (conn: Conn<ResponseEnded, Data>) -> NSView in
+        @Dependency(\.renderHtml) var renderHtml;
+
         let webView = WKWebView(frame: .init(origin: .zero, size: size))
-        webView.loadHTMLString(
-          String(
-            decoding: withDependencies {
-              $0.renderHtml = { Html.render($0) }
-            } operation: {
-              conn.data
-            },
-            as: UTF8.self
-          ),
-          baseURL: nil
-        )
+        webView.loadHTMLString(String(decoding: conn.data, as: UTF8.self), baseURL: nil)
         return webView
       }
+
+    snapshotting.snapshot = { [snapshot = snapshotting.snapshot] value in
+      try await withDependencies {
+        $0.renderHtml = { Html.render($0) }
+      } operation: {
+        try await snapshot { try await value() }
+      }
     }
-  #endif
+
+    return snapshotting
+  }
+#endif
 }
 
 public func request(

--- a/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
+++ b/Sources/PointFreeTestSupport/PointFreeTestSupport.swift
@@ -96,6 +96,27 @@ extension Snapshotting {
 
   #if os(macOS)
     @available(OSX 10.13, *)
+    public static func connWebView(
+      size: CGSize
+    ) -> Snapshotting<Conn<ResponseEnded, Data>, NSImage> {
+      return Snapshotting<NSView, NSImage>.image.pullback { @MainActor conn in
+        let webView = WKWebView(frame: .init(origin: .zero, size: size))
+        webView.loadHTMLString(
+          String(
+            decoding: withDependencies {
+              $0.renderHtml = { Html.render($0) }
+            } operation: {
+              conn.data
+            },
+            as: UTF8.self
+          ),
+          baseURL: nil
+        )
+        return webView
+      }
+    }
+
+    @available(OSX 10.13, *)
     public static func ioConnWebView(size: CGSize) -> Snapshotting<
       IO<Conn<ResponseEnded, Data>>, NSImage
     > {

--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -23,7 +23,7 @@ struct Server {
 
     run(
       { conn in
-        IO { await _siteMiddleware(conn) }
+        IO { await siteMiddleware(conn) }
       },
       on: envVars.port,
       eventLoopGroup: eventLoopGroup,

--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -22,7 +22,9 @@ struct Server {
     // Server
 
     run(
-      siteMiddleware,
+      { conn in
+        IO { await _siteMiddleware(conn) }
+      },
       on: envVars.port,
       eventLoopGroup: eventLoopGroup,
       gzip: true,

--- a/Tests/PointFreeTests/AboutTests.swift
+++ b/Tests/PointFreeTests/AboutTests.swift
@@ -16,7 +16,7 @@ class AboutTests: TestCase {
     //SnapshotTesting.isRecording=true
     let conn = connection(from: request(to: .about))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {

--- a/Tests/PointFreeTests/AboutTests.swift
+++ b/Tests/PointFreeTests/AboutTests.swift
@@ -16,15 +16,15 @@ class AboutTests: TestCase {
     //SnapshotTesting.isRecording=true
     let conn = connection(from: request(to: .about))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 2300)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 2300)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 2300)),
+            "mobile": .connWebView(size: .init(width: 400, height: 2300)),
           ]
         )
       }

--- a/Tests/PointFreeTests/AccountTests/AccountTests.swift
+++ b/Tests/PointFreeTests/AccountTests/AccountTests.swift
@@ -58,7 +58,7 @@ final class AccountIntegrationTests: LiveDatabaseTestCase {
 
     let conn = connection(from: request(to: .team(.leave), session: .loggedIn(as: currentUser)))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
     XCTAssertEqual(subscriptionId, nil)
@@ -80,15 +80,15 @@ final class AccountTests: TestCase {
       $0.teamYearly()
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await _siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 2800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 2400)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 2800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 2400)),
             ]
           )
         }
@@ -107,7 +107,7 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -139,7 +139,7 @@ final class AccountTests: TestCase {
       session.user = .standard(currentUser.id)
       let conn = connection(from: request(to: .account(), session: session))
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -174,7 +174,7 @@ final class AccountTests: TestCase {
       session.user = .standard(currentUser.id)
       let conn = connection(from: request(to: .account(), session: session))
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -195,7 +195,7 @@ final class AccountTests: TestCase {
       $0.teamYearlyTeammate()
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn(as: .teammate)))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -219,7 +219,7 @@ final class AccountTests: TestCase {
       )
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn(as: .teammate)))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -246,7 +246,7 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -269,7 +269,7 @@ final class AccountTests: TestCase {
     let conn = connection(
       from: request(to: .account(), session: session))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -290,7 +290,7 @@ final class AccountTests: TestCase {
 
     let conn = connection(from: request(to: .account(), session: session))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -311,7 +311,7 @@ final class AccountTests: TestCase {
 
     let conn = connection(from: request(to: .account(), session: session))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -340,7 +340,7 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in stripeSubscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -361,7 +361,7 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceling }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -383,7 +383,7 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceled }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -410,7 +410,7 @@ final class AccountTests: TestCase {
       $0.database.fetchSubscriptionByOwnerId = { _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -437,7 +437,7 @@ final class AccountTests: TestCase {
       $0.database.fetchSubscriptionByOwnerId = { _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -462,7 +462,7 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -487,7 +487,7 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {

--- a/Tests/PointFreeTests/AccountTests/AccountTests.swift
+++ b/Tests/PointFreeTests/AccountTests/AccountTests.swift
@@ -58,7 +58,7 @@ final class AccountIntegrationTests: LiveDatabaseTestCase {
 
     let conn = connection(from: request(to: .team(.leave), session: .loggedIn(as: currentUser)))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
     XCTAssertEqual(subscriptionId, nil)
@@ -80,12 +80,12 @@ final class AccountTests: TestCase {
       $0.teamYearly()
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: await _siteMiddleware(conn),
+            matching: await siteMiddleware(conn),
             as: [
               "desktop": .connWebView(size: .init(width: 1080, height: 2800)),
               "mobile": .connWebView(size: .init(width: 400, height: 2400)),
@@ -107,15 +107,15 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 2800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 2400)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 2800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 2400)),
             ]
           )
         }
@@ -139,15 +139,15 @@ final class AccountTests: TestCase {
       session.user = .standard(currentUser.id)
       let conn = connection(from: request(to: .account(), session: session))
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1800)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 2000)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1800)),
             ]
           )
         }
@@ -174,15 +174,15 @@ final class AccountTests: TestCase {
       session.user = .standard(currentUser.id)
       let conn = connection(from: request(to: .account(), session: session))
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1600)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1600)),
             ]
           )
         }
@@ -195,15 +195,15 @@ final class AccountTests: TestCase {
       $0.teamYearlyTeammate()
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn(as: .teammate)))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1500)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1300)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1500)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1300)),
             ]
           )
         }
@@ -219,15 +219,15 @@ final class AccountTests: TestCase {
       )
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn(as: .teammate)))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1500)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1300)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1500)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1300)),
             ]
           )
         }
@@ -246,15 +246,15 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1000)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1000)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1000)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1000)),
             ]
           )
         }
@@ -269,15 +269,15 @@ final class AccountTests: TestCase {
     let conn = connection(
       from: request(to: .account(), session: session))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 80)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 80)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 80)),
+            "mobile": .connWebView(size: .init(width: 400, height: 80)),
           ]
         )
       }
@@ -290,15 +290,15 @@ final class AccountTests: TestCase {
 
     let conn = connection(from: request(to: .account(), session: session))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 80)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 80)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 80)),
+            "mobile": .connWebView(size: .init(width: 400, height: 80)),
           ]
         )
       }
@@ -311,15 +311,15 @@ final class AccountTests: TestCase {
 
     let conn = connection(from: request(to: .account(), session: session))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 80)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 80)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 80)),
+            "mobile": .connWebView(size: .init(width: 400, height: 80)),
           ]
         )
       }
@@ -340,15 +340,15 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in stripeSubscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1800)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 2000)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1800)),
             ]
           )
         }
@@ -361,15 +361,15 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceling }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 2200)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 2000)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 2200)),
+              "mobile": .connWebView(size: .init(width: 400, height: 2000)),
             ]
           )
         }
@@ -383,15 +383,15 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceled }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1400)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1200)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1400)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1200)),
             ]
           )
         }
@@ -410,15 +410,15 @@ final class AccountTests: TestCase {
       $0.database.fetchSubscriptionByOwnerId = { _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1200)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1000)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1200)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1000)),
             ]
           )
         }
@@ -437,15 +437,15 @@ final class AccountTests: TestCase {
       $0.database.fetchSubscriptionByOwnerId = { _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1200)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1000)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1200)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1000)),
             ]
           )
         }
@@ -462,15 +462,15 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 2400)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 2000)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 2400)),
+              "mobile": .connWebView(size: .init(width: 400, height: 2000)),
             ]
           )
         }
@@ -487,15 +487,15 @@ final class AccountTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 2800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 2400)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 2800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 2400)),
             ]
           )
         }

--- a/Tests/PointFreeTests/AccountTests/CancelTests.swift
+++ b/Tests/PointFreeTests/AccountTests/CancelTests.swift
@@ -44,7 +44,7 @@ final class CancelTests: TestCase {
       }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       XCTAssertEqual(false, immediately)
     }
 
@@ -63,7 +63,7 @@ final class CancelTests: TestCase {
       }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       XCTAssertEqual(true, immediately)
     }
   }
@@ -71,7 +71,7 @@ final class CancelTests: TestCase {
   func testCancelLoggedOut() async throws {
     let conn = connection(from: request(to: .account(.subscription(.cancel))))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testCancelNoSubscription() async throws {
@@ -79,7 +79,7 @@ final class CancelTests: TestCase {
       $0.stripe.fetchSubscription = { _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -88,7 +88,7 @@ final class CancelTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceling }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -97,7 +97,7 @@ final class CancelTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceled }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -106,7 +106,7 @@ final class CancelTests: TestCase {
       $0.stripe.cancelSubscription = { _, _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -134,14 +134,14 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
   func testReactivateLoggedOut() async throws {
     let conn = connection(from: request(to: .account(.subscription(.reactivate))))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testReactivateNoSubscription() async throws {
@@ -150,7 +150,7 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -158,7 +158,7 @@ final class CancelTests: TestCase {
     let conn = connection(
       from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testReactivateCanceledSubscription() async throws {
@@ -167,7 +167,7 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -177,7 +177,7 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 

--- a/Tests/PointFreeTests/AccountTests/CancelTests.swift
+++ b/Tests/PointFreeTests/AccountTests/CancelTests.swift
@@ -44,7 +44,7 @@ final class CancelTests: TestCase {
       }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       XCTAssertEqual(false, immediately)
     }
 
@@ -63,7 +63,7 @@ final class CancelTests: TestCase {
       }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       XCTAssertEqual(true, immediately)
     }
   }
@@ -71,7 +71,7 @@ final class CancelTests: TestCase {
   func testCancelLoggedOut() async throws {
     let conn = connection(from: request(to: .account(.subscription(.cancel))))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testCancelNoSubscription() async throws {
@@ -79,7 +79,7 @@ final class CancelTests: TestCase {
       $0.stripe.fetchSubscription = { _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -88,7 +88,7 @@ final class CancelTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceling }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -97,7 +97,7 @@ final class CancelTests: TestCase {
       $0.stripe.fetchSubscription = { _ in .canceled }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -106,7 +106,7 @@ final class CancelTests: TestCase {
       $0.stripe.cancelSubscription = { _, _ in throw unit }
     } operation: {
       let conn = connection(from: request(to: .account(.subscription(.cancel)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -134,14 +134,14 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
   func testReactivateLoggedOut() async throws {
     let conn = connection(from: request(to: .account(.subscription(.reactivate))))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testReactivateNoSubscription() async throws {
@@ -150,7 +150,7 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -158,7 +158,7 @@ final class CancelTests: TestCase {
     let conn = connection(
       from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testReactivateCanceledSubscription() async throws {
@@ -167,7 +167,7 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -177,7 +177,7 @@ final class CancelTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .account(.subscription(.reactivate)), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 

--- a/Tests/PointFreeTests/AccountTests/ChangeTests.swift
+++ b/Tests/PointFreeTests/AccountTests/ChangeTests.swift
@@ -29,7 +29,7 @@ final class ChangeTests: TestCase {
       } operation: {
         let conn = connection(
           from: request(to: .account(.subscription(.change(.show))), session: .loggedIn))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -46,7 +46,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.individualYearly)))), session: .loggedIn))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -63,7 +63,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.individualMonthly)))), session: .loggedIn))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -80,7 +80,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamYearly)))), session: .loggedIn))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -97,7 +97,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamMonthly)))), session: .loggedIn))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -110,7 +110,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamMonthly)))), session: .loggedIn))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -123,7 +123,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamYearly)))), session: .loggedIn))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -138,10 +138,8 @@ final class ChangeTests: TestCase {
 
         let conn = connection(
           from: request(to: .account(.subscription(.change(.update(pricing)))), session: .loggedIn))
-        let result = conn |> siteMiddleware
-
-        let performed = await result.performAsync()
-        await assertSnapshot(matching: performed, as: .conn)
+        let result = await siteMiddleware(conn)
+        await assertSnapshot(matching: result, as: .conn)
       }
     #endif
   }
@@ -161,7 +159,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(to: .account(.subscription(.change(.update(pricing)))), session: .loggedIn))
 
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -184,7 +182,7 @@ final class ChangeTests: TestCase {
           from: request(to: .account(.subscription(.change(.update(pricing)))), session: .loggedIn)
         )
 
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     #endif
   }

--- a/Tests/PointFreeTests/AccountTests/ChangeTests.swift
+++ b/Tests/PointFreeTests/AccountTests/ChangeTests.swift
@@ -29,7 +29,7 @@ final class ChangeTests: TestCase {
       } operation: {
         let conn = connection(
           from: request(to: .account(.subscription(.change(.show))), session: .loggedIn))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -46,7 +46,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.individualYearly)))), session: .loggedIn))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -63,7 +63,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.individualMonthly)))), session: .loggedIn))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -80,7 +80,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamYearly)))), session: .loggedIn))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -97,7 +97,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamMonthly)))), session: .loggedIn))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -110,7 +110,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamMonthly)))), session: .loggedIn))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -123,7 +123,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(
             to: .account(.subscription(.change(.update(.teamYearly)))), session: .loggedIn))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -161,7 +161,7 @@ final class ChangeTests: TestCase {
         let conn = connection(
           from: request(to: .account(.subscription(.change(.update(pricing)))), session: .loggedIn))
 
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }
@@ -184,7 +184,7 @@ final class ChangeTests: TestCase {
           from: request(to: .account(.subscription(.change(.update(pricing)))), session: .loggedIn)
         )
 
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     #endif
   }

--- a/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
+++ b/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
@@ -25,15 +25,15 @@ class PaymentInfoTests: TestCase {
   func testRender() async throws {
     let conn = connection(from: request(to: .account(.paymentInfo()), session: .loggedIn))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 2000)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 2000)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 2000)),
+            "mobile": .connWebView(size: .init(width: 400, height: 2000)),
           ]
         )
       }
@@ -51,7 +51,7 @@ class PaymentInfoTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(.paymentInfo()), session: .loggedIn))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
+++ b/Tests/PointFreeTests/AccountTests/PaymentInfoTests.swift
@@ -25,7 +25,7 @@ class PaymentInfoTests: TestCase {
   func testRender() async throws {
     let conn = connection(from: request(to: .account(.paymentInfo()), session: .loggedIn))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -51,7 +51,7 @@ class PaymentInfoTests: TestCase {
       $0.stripe.fetchSubscription = { _ in subscription }
     } operation: {
       let conn = connection(from: request(to: .account(.paymentInfo()), session: .loggedIn))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/AccountTests/UpdateProfileTests.swift
+++ b/Tests/PointFreeTests/AccountTests/UpdateProfileTests.swift
@@ -45,7 +45,7 @@ class UpdateProfileIntegrationTests: LiveDatabaseTestCase {
       session: .init(flash: nil, userId: user.id)
     )
 
-    let output = await siteMiddleware(connection(from: update)).performAsync()
+    let output = await siteMiddleware(connection(from: update))
 
     user = try await self.database.fetchUserById(user.id)
     user.referralCode = "deadbeef"
@@ -83,7 +83,7 @@ class UpdateProfileIntegrationTests: LiveDatabaseTestCase {
       session: .init(flash: nil, userId: user.id)
     )
 
-    let output = await siteMiddleware(connection(from: update)).performAsync()
+    let output = await siteMiddleware(connection(from: update))
 
     let settings = try await self.database.fetchEmailSettingsForUserId(user.id)
     await assertSnapshot(
@@ -137,7 +137,7 @@ class UpdateProfileTests: TestCase {
           userId: .init(rawValue: UUID.init(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!))
       )
 
-      let output = await siteMiddleware(connection(from: update)).performAsync()
+      let output = await siteMiddleware(connection(from: update))
 
       #if !os(Linux)
         await assertSnapshot(matching: output, as: .conn)

--- a/Tests/PointFreeTests/ApiTests.swift
+++ b/Tests/PointFreeTests/ApiTests.swift
@@ -14,12 +14,12 @@ final class ApiTests: TestCase {
   }
 
   func testEpisodes() async throws {
-    let conn = await siteMiddleware(connection(from: request(to: .api(.episodes)))).performAsync()
+    let conn = await siteMiddleware(connection(from: request(to: .api(.episodes))))
     await assertSnapshot(matching: conn, as: .conn)
   }
 
   func testEpisode() async throws {
-    let conn = await siteMiddleware(connection(from: request(to: .api(.episode(1))))).performAsync()
+    let conn = await siteMiddleware(connection(from: request(to: .api(.episode(1)))))
     #if !os(Linux)
       // Can't run on Linux because of https://bugs.swift.org/browse/SR-11410
       await assertSnapshot(matching: conn, as: .conn)
@@ -28,7 +28,6 @@ final class ApiTests: TestCase {
 
   func testEpisode_NotFound() async throws {
     let conn = await siteMiddleware(connection(from: request(to: .api(.episode(424242)))))
-      .performAsync()
     await assertSnapshot(matching: conn, as: .conn)
   }
 }

--- a/Tests/PointFreeTests/AppleDeveloperMerchantIdDomainAssociationTests.swift
+++ b/Tests/PointFreeTests/AppleDeveloperMerchantIdDomainAssociationTests.swift
@@ -13,7 +13,6 @@ final class AppleDeveloperMerchantIdDomainAssociationTests: TestCase {
     let conn = await siteMiddleware(
       connection(from: request(to: .appleDeveloperMerchantIdDomainAssociation))
     )
-    .performAsync()
 
     await assertSnapshot(matching: conn, as: .conn)
   }

--- a/Tests/PointFreeTests/AtomFeedTests.swift
+++ b/Tests/PointFreeTests/AtomFeedTests.swift
@@ -23,7 +23,7 @@ class AtomFeedTests: TestCase {
     } operation: {
       let conn = connection(from: request(to: .feed(.atom)))
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -33,7 +33,7 @@ class AtomFeedTests: TestCase {
     } operation: {
       let conn = connection(from: request(to: .feed(.episodes)))
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -55,7 +55,7 @@ class AtomFeedTests: TestCase {
         $0.episodes = { [recentlyFreeEpisode, freeEpisode] }
       } operation: {
         let conn = connection(from: request(to: .feed(.episodes)))
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       }
     }
   }

--- a/Tests/PointFreeTests/AtomFeedTests.swift
+++ b/Tests/PointFreeTests/AtomFeedTests.swift
@@ -23,7 +23,7 @@ class AtomFeedTests: TestCase {
     } operation: {
       let conn = connection(from: request(to: .feed(.atom)))
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -33,7 +33,7 @@ class AtomFeedTests: TestCase {
     } operation: {
       let conn = connection(from: request(to: .feed(.episodes)))
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -55,7 +55,7 @@ class AtomFeedTests: TestCase {
         $0.episodes = { [recentlyFreeEpisode, freeEpisode] }
       } operation: {
         let conn = connection(from: request(to: .feed(.episodes)))
-        await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       }
     }
   }

--- a/Tests/PointFreeTests/AuthTests.swift
+++ b/Tests/PointFreeTests/AuthTests.swift
@@ -88,7 +88,7 @@ class AuthIntegrationTests: LiveDatabaseTestCase {
     let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
     let conn = connection(from: auth)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testLoginWithRedirect() async throws {
@@ -98,7 +98,7 @@ class AuthIntegrationTests: LiveDatabaseTestCase {
       to: .login(redirect: siteRouter.url(for: .episode(.show(.right(42))))), session: .loggedIn)
     let conn = connection(from: login)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 }
 
@@ -116,7 +116,7 @@ class AuthTests: TestCase {
     } operation: {
       let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -128,7 +128,7 @@ class AuthTests: TestCase {
     } operation: {
       let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -144,7 +144,7 @@ class AuthTests: TestCase {
         to: .gitHubCallback(
           code: "deadbeef", redirect: siteRouter.url(for: .episode(.show(.right(42))))))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -154,7 +154,7 @@ class AuthTests: TestCase {
     } operation: {
       let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -162,31 +162,31 @@ class AuthTests: TestCase {
     let login = request(to: .login(redirect: nil))
     let conn = connection(from: login)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testLogin_AlreadyLoggedIn() async throws {
     let login = request(to: .login(redirect: nil), session: .loggedIn)
     let conn = connection(from: login)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testLogout() async throws {
     let conn = connection(from: request(to: .logout))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testHome_LoggedOut() async throws {
     let conn = connection(from: request(to: .home, session: .loggedOut))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testHome_LoggedIn() async throws {
     let conn = connection(from: request(to: .home, session: .loggedIn))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 }

--- a/Tests/PointFreeTests/AuthTests.swift
+++ b/Tests/PointFreeTests/AuthTests.swift
@@ -39,7 +39,6 @@ class AuthIntegrationTests: LiveDatabaseTestCase {
           from: request(to: .gitHubCallback(code: "deabeef", redirect: "/"), session: .loggedOut)
         )
       )
-      .performAsync()
       await assertSnapshot(matching: result, as: .conn)
 
       let registeredUser = try await self.database
@@ -71,7 +70,6 @@ class AuthIntegrationTests: LiveDatabaseTestCase {
           from: request(to: .gitHubCallback(code: "deabeef", redirect: "/"), session: .loggedOut)
         )
       )
-      .performAsync()
       await assertSnapshot(matching: result, as: .conn)
 
       let registeredUser = try await self.database
@@ -88,7 +86,7 @@ class AuthIntegrationTests: LiveDatabaseTestCase {
     let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
     let conn = connection(from: auth)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testLoginWithRedirect() async throws {
@@ -98,7 +96,7 @@ class AuthIntegrationTests: LiveDatabaseTestCase {
       to: .login(redirect: siteRouter.url(for: .episode(.show(.right(42))))), session: .loggedIn)
     let conn = connection(from: login)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 }
 
@@ -116,7 +114,7 @@ class AuthTests: TestCase {
     } operation: {
       let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -128,7 +126,7 @@ class AuthTests: TestCase {
     } operation: {
       let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -144,7 +142,7 @@ class AuthTests: TestCase {
         to: .gitHubCallback(
           code: "deadbeef", redirect: siteRouter.url(for: .episode(.show(.right(42))))))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -154,7 +152,7 @@ class AuthTests: TestCase {
     } operation: {
       let auth = request(to: .gitHubCallback(code: "deadbeef", redirect: nil))
       let conn = connection(from: auth)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -162,31 +160,31 @@ class AuthTests: TestCase {
     let login = request(to: .login(redirect: nil))
     let conn = connection(from: login)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testLogin_AlreadyLoggedIn() async throws {
     let login = request(to: .login(redirect: nil), session: .loggedIn)
     let conn = connection(from: login)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testLogout() async throws {
     let conn = connection(from: request(to: .logout))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testHome_LoggedOut() async throws {
     let conn = connection(from: request(to: .home, session: .loggedOut))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testHome_LoggedIn() async throws {
     let conn = connection(from: request(to: .home, session: .loggedIn))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 }

--- a/Tests/PointFreeTests/BlogTests.swift
+++ b/Tests/PointFreeTests/BlogTests.swift
@@ -28,7 +28,7 @@ class BlogTests: TestCase {
   func testBlogIndex() async throws {
     let conn = connection(from: request(to: .blog()))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -62,7 +62,7 @@ class BlogTests: TestCase {
       $0.blogPosts = unzurry(posts)
     } operation: {
       let conn = connection(from: request(to: .blog()))
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -82,7 +82,7 @@ class BlogTests: TestCase {
     let slug = self.blogPosts().first!.slug
     let conn = connection(from: request(to: .blog(.show(slug: slug))))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -101,16 +101,16 @@ class BlogTests: TestCase {
     let slug = self.blogPosts().first!.slug
     let conn = connection(from: request(to: .blog(.show(slug: slug))))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testBlogAtomFeed() async throws {
     let conn = connection(from: request(to: .blog(.feed)))
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testBlogAtomFeed_Unauthed() async throws {
     let conn = connection(from: request(to: .blog(.feed)))
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 }

--- a/Tests/PointFreeTests/BlogTests.swift
+++ b/Tests/PointFreeTests/BlogTests.swift
@@ -28,15 +28,15 @@ class BlogTests: TestCase {
   func testBlogIndex() async throws {
     let conn = connection(from: request(to: .blog()))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 2000)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 2000)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 2000)),
+            "mobile": .connWebView(size: .init(width: 500, height: 2000)),
           ]
         )
       }
@@ -62,15 +62,15 @@ class BlogTests: TestCase {
       $0.blogPosts = unzurry(posts)
     } operation: {
       let conn = connection(from: request(to: .blog()))
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2400)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2400)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2400)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2400)),
             ]
           )
         }
@@ -82,15 +82,15 @@ class BlogTests: TestCase {
     let slug = self.blogPosts().first!.slug
     let conn = connection(from: request(to: .blog(.show(slug: slug))))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 2000)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 2000)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 2000)),
+            "mobile": .connWebView(size: .init(width: 500, height: 2000)),
           ]
         )
       }
@@ -101,16 +101,16 @@ class BlogTests: TestCase {
     let slug = self.blogPosts().first!.slug
     let conn = connection(from: request(to: .blog(.show(slug: slug))))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testBlogAtomFeed() async throws {
     let conn = connection(from: request(to: .blog(.feed)))
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testBlogAtomFeed_Unauthed() async throws {
     let conn = connection(from: request(to: .blog(.feed)))
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 }

--- a/Tests/PointFreeTests/CollectionsTests.swift
+++ b/Tests/PointFreeTests/CollectionsTests.swift
@@ -38,15 +38,15 @@ class CollectionsTests: TestCase {
         from: request(to: .collections(), basicAuth: true)
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 1500)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 1900)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 1500)),
+              "mobile": .connWebView(size: .init(width: 500, height: 1900)),
             ]
           )
         }
@@ -59,15 +59,15 @@ class CollectionsTests: TestCase {
       from: request(to: .collections(.collection(self.collections[0].slug)), basicAuth: true)
     )
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 1100)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 1100)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 1100)),
+            "mobile": .connWebView(size: .init(width: 500, height: 1100)),
           ]
         )
       }
@@ -87,15 +87,15 @@ class CollectionsTests: TestCase {
       )
     )
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 1800)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 1800)),
+            "mobile": .connWebView(size: .init(width: 500, height: 1800)),
           ]
         )
       }

--- a/Tests/PointFreeTests/CollectionsTests.swift
+++ b/Tests/PointFreeTests/CollectionsTests.swift
@@ -38,7 +38,7 @@ class CollectionsTests: TestCase {
         from: request(to: .collections(), basicAuth: true)
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -59,7 +59,7 @@ class CollectionsTests: TestCase {
       from: request(to: .collections(.collection(self.collections[0].slug)), basicAuth: true)
     )
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -87,7 +87,7 @@ class CollectionsTests: TestCase {
       )
     )
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {

--- a/Tests/PointFreeTests/DiscountsTests.swift
+++ b/Tests/PointFreeTests/DiscountsTests.swift
@@ -23,7 +23,7 @@ class DiscountsTests: TestCase {
 
   func testDiscounts_LoggedOut() async throws {
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: request(to: .discounts(code: "blobfest", nil)))
       ),
       as: .conn
@@ -32,11 +32,12 @@ class DiscountsTests: TestCase {
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: connection(from: request(to: .discounts(code: "blobfest", nil)))
-            |> siteMiddleware,
+          matching: await siteMiddleware(
+            connection(from: request(to: .discounts(code: "blobfest", nil)))
+          ),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 2000)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 2000)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 2000)),
+            "mobile": .connWebView(size: .init(width: 500, height: 2000)),
           ]
         )
       }
@@ -58,7 +59,7 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: await _siteMiddleware(
+        matching: await siteMiddleware(
           connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
         ),
         as: .conn
@@ -67,13 +68,12 @@ class DiscountsTests: TestCase {
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: connection(
-              from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn)
-            )
-              |> siteMiddleware,
+            matching: await siteMiddleware(
+              connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
+            ),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2000)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2000)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2000)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2000)),
             ]
           )
         }
@@ -96,7 +96,7 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: await _siteMiddleware(
+        matching: await siteMiddleware(
           connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
         ),
         as: .conn
@@ -119,7 +119,7 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: await _siteMiddleware(
+        matching: await siteMiddleware(
           connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
         ),
         as: .conn
@@ -142,7 +142,7 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: await _siteMiddleware(
+        matching: await siteMiddleware(
           connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
         ),
         as: .conn
@@ -165,7 +165,7 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: await _siteMiddleware(
+        matching: await siteMiddleware(
           connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
         ),
         as: .conn
@@ -188,7 +188,7 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: await _siteMiddleware(
+        matching: await siteMiddleware(
           connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
         ),
         as: .conn
@@ -200,7 +200,7 @@ class DiscountsTests: TestCase {
     @Dependency(\.envVars.regionalDiscountCouponId) var regionalDiscountCouponId: Coupon.ID
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(
           from: request(to: .discounts(code: regionalDiscountCouponId, nil))
         )

--- a/Tests/PointFreeTests/DiscountsTests.swift
+++ b/Tests/PointFreeTests/DiscountsTests.swift
@@ -23,9 +23,10 @@ class DiscountsTests: TestCase {
 
   func testDiscounts_LoggedOut() async throws {
     await assertSnapshot(
-      matching: connection(from: request(to: .discounts(code: "blobfest", nil)))
-        |> siteMiddleware,
-      as: .ioConn
+      matching: await _siteMiddleware(
+        connection(from: request(to: .discounts(code: "blobfest", nil)))
+      ),
+      as: .conn
     )
 
     #if !os(Linux)
@@ -57,10 +58,10 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: connection(
-          from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
-          |> siteMiddleware,
-        as: .ioConn
+        matching: await _siteMiddleware(
+          connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
+        ),
+        as: .conn
       )
 
       #if !os(Linux)
@@ -95,10 +96,10 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: connection(
-          from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
-          |> siteMiddleware,
-        as: .ioConn
+        matching: await _siteMiddleware(
+          connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
+        ),
+        as: .conn
       )
     }
   }
@@ -118,10 +119,10 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: connection(
-          from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
-          |> siteMiddleware,
-        as: .ioConn
+        matching: await _siteMiddleware(
+          connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
+        ),
+        as: .conn
       )
     }
   }
@@ -141,10 +142,10 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: connection(
-          from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
-          |> siteMiddleware,
-        as: .ioConn
+        matching: await _siteMiddleware(
+          connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
+        ),
+        as: .conn
       )
     }
   }
@@ -164,10 +165,10 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: connection(
-          from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
-          |> siteMiddleware,
-        as: .ioConn
+        matching: await _siteMiddleware(
+          connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
+        ),
+        as: .conn
       )
     }
   }
@@ -187,10 +188,10 @@ class DiscountsTests: TestCase {
       $0.stripe.fetchCoupon = { _ in fiftyPercentOffForever }
     } operation: {
       await assertSnapshot(
-        matching: connection(
-          from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
-          |> siteMiddleware,
-        as: .ioConn
+        matching: await _siteMiddleware(
+          connection(from: request(to: .discounts(code: "blobfest", nil), session: .loggedIn))
+        ),
+        as: .conn
       )
     }
   }
@@ -199,12 +200,12 @@ class DiscountsTests: TestCase {
     @Dependency(\.envVars.regionalDiscountCouponId) var regionalDiscountCouponId: Coupon.ID
 
     await assertSnapshot(
-      matching: siteMiddleware(
+      matching: await _siteMiddleware(
         connection(
           from: request(to: .discounts(code: regionalDiscountCouponId, nil))
         )
       ),
-      as: .ioConn
+      as: .conn
     )
   }
 }

--- a/Tests/PointFreeTests/EnterpriseTests.swift
+++ b/Tests/PointFreeTests/EnterpriseTests.swift
@@ -34,7 +34,7 @@ class EnterpriseTests: TestCase {
     } operation: {
       let req = request(to: .enterprise(account.domain))
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -58,7 +58,7 @@ class EnterpriseTests: TestCase {
     } operation: {
       let req = request(to: .enterprise(account.domain))
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -74,7 +74,7 @@ class EnterpriseTests: TestCase {
     } operation: {
       let req = request(to: .enterprise(account.domain), session: .loggedIn(as: user))
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -86,7 +86,7 @@ class EnterpriseTests: TestCase {
       session: .loggedOut
     )
     let conn = connection(from: req)
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testAcceptInvitation_BadEmail() async throws {
@@ -108,7 +108,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -131,7 +131,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -156,7 +156,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -180,7 +180,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -203,7 +203,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -228,7 +228,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
 
     // todo: more verifications that subscription was linked

--- a/Tests/PointFreeTests/EnterpriseTests.swift
+++ b/Tests/PointFreeTests/EnterpriseTests.swift
@@ -34,15 +34,15 @@ class EnterpriseTests: TestCase {
     } operation: {
       let req = request(to: .enterprise(account.domain))
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 700)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 700)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 700)),
+              "mobile": .connWebView(size: .init(width: 500, height: 700)),
             ]
           )
         }
@@ -58,7 +58,7 @@ class EnterpriseTests: TestCase {
     } operation: {
       let req = request(to: .enterprise(account.domain))
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -74,7 +74,7 @@ class EnterpriseTests: TestCase {
     } operation: {
       let req = request(to: .enterprise(account.domain), session: .loggedIn(as: user))
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -86,7 +86,7 @@ class EnterpriseTests: TestCase {
       session: .loggedOut
     )
     let conn = connection(from: req)
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testAcceptInvitation_BadEmail() async throws {
@@ -108,7 +108,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -131,7 +131,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -156,7 +156,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -180,7 +180,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -203,7 +203,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -228,7 +228,7 @@ class EnterpriseTests: TestCase {
         session: .loggedIn(as: loggedInUser)
       )
       let conn = connection(from: req)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
 
     // todo: more verifications that subscription was linked

--- a/Tests/PointFreeTests/EpisodePageTests.swift
+++ b/Tests/PointFreeTests/EpisodePageTests.swift
@@ -48,7 +48,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([credit], credits)
@@ -76,7 +76,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([], credits)
@@ -104,7 +104,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([], credits)
@@ -134,7 +134,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([credit], credits)
@@ -173,7 +173,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -205,7 +205,7 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -236,7 +236,7 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -257,7 +257,7 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -284,7 +284,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -311,7 +311,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -338,7 +338,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -359,7 +359,7 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -389,7 +389,7 @@ class EpisodePageTests: TestCase {
         from: request(to: .episode(.show(.left(episode.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -424,7 +424,7 @@ class EpisodePageTests: TestCase {
           to: .episode(.show(.left(self.episodes().first!.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -459,7 +459,7 @@ class EpisodePageTests: TestCase {
           to: .episode(.show(.left(self.episodes().first!.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -494,7 +494,7 @@ class EpisodePageTests: TestCase {
           to: .episode(.show(.left(self.episodes().first!.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -572,7 +572,7 @@ class EpisodePageTests: TestCase {
         }
       #endif
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -588,7 +588,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -606,7 +606,7 @@ class EpisodePageTests: TestCase {
       )
       let conn = connection(from: progressRequest)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       XCTAssertEqual(didUpdate, true)
     }
   }
@@ -624,7 +624,7 @@ class EpisodePageTests: TestCase {
       )
       let conn = connection(from: progressRequest)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       XCTAssertEqual(didUpdate, false)
     }
   }
@@ -638,7 +638,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/EpisodePageTests.swift
+++ b/Tests/PointFreeTests/EpisodePageTests.swift
@@ -48,7 +48,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([credit], credits)
@@ -76,7 +76,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([], credits)
@@ -104,7 +104,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([], credits)
@@ -134,7 +134,7 @@ class EpisodePageIntegrationTests: LiveDatabaseTestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       let credits = try await self.database.fetchEpisodeCredits(user.id)
       XCTAssertEqual([credit], credits)
@@ -173,15 +173,15 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2400)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2400)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2400)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2400)),
             ]
           )
         }
@@ -205,15 +205,15 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 2400)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 2400)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 2400)),
+            "mobile": .connWebView(size: .init(width: 500, height: 2400)),
           ]
         )
       }
@@ -236,15 +236,15 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 2400)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 2400)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 2400)),
+            "mobile": .connWebView(size: .init(width: 500, height: 2400)),
           ]
         )
       }
@@ -257,15 +257,15 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1100, height: 2600)),
-            "mobile": .ioConnWebView(size: .init(width: 500, height: 2600)),
+            "desktop": .connWebView(size: .init(width: 1100, height: 2600)),
+            "mobile": .connWebView(size: .init(width: 500, height: 2600)),
           ]
         )
       }
@@ -284,15 +284,15 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2600)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2600)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2600)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2600)),
             ]
           )
         }
@@ -311,15 +311,15 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2100)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2100)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2100)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2100)),
             ]
           )
         }
@@ -338,15 +338,15 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2100)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2100)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2100)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2100)),
             ]
           )
         }
@@ -359,13 +359,13 @@ class EpisodePageTests: TestCase {
 
     let conn = connection(from: episode)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshot(
-          matching: conn |> siteMiddleware,
-          as: .ioConnWebView(size: .init(width: 1100, height: 1000))
+          matching: await siteMiddleware(conn),
+          as: .connWebView(size: .init(width: 1100, height: 1000))
         )
       }
     #endif
@@ -389,15 +389,15 @@ class EpisodePageTests: TestCase {
         from: request(to: .episode(.show(.left(episode.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 1800)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 1800)),
+              "mobile": .connWebView(size: .init(width: 500, height: 1800)),
             ]
           )
         }
@@ -424,15 +424,15 @@ class EpisodePageTests: TestCase {
           to: .episode(.show(.left(self.episodes().first!.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 1800)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 1800)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 1800)),
+              "mobile": .connWebView(size: .init(width: 500, height: 1800)),
             ]
           )
         }
@@ -459,15 +459,15 @@ class EpisodePageTests: TestCase {
           to: .episode(.show(.left(self.episodes().first!.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2300)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2300)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2300)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2300)),
             ]
           )
         }
@@ -494,15 +494,15 @@ class EpisodePageTests: TestCase {
           to: .episode(.show(.left(self.episodes().first!.slug))), session: .loggedIn)
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2300)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2300)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2300)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2300)),
             ]
           )
         }
@@ -554,7 +554,7 @@ class EpisodePageTests: TestCase {
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
           let html = await String(
-            decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self
+            decoding: siteMiddleware(conn).data, as: UTF8.self
           )
           webView.loadHTMLString(html, baseURL: nil)
           await assertSnapshot(matching: webView, as: .image, named: "desktop")
@@ -572,7 +572,7 @@ class EpisodePageTests: TestCase {
         }
       #endif
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -588,7 +588,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -606,7 +606,7 @@ class EpisodePageTests: TestCase {
       )
       let conn = connection(from: progressRequest)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       XCTAssertEqual(didUpdate, true)
     }
   }
@@ -624,7 +624,7 @@ class EpisodePageTests: TestCase {
       )
       let conn = connection(from: progressRequest)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       XCTAssertEqual(didUpdate, false)
     }
   }
@@ -638,7 +638,7 @@ class EpisodePageTests: TestCase {
 
       let conn = connection(from: episode)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/EpisodePageTests.swift
+++ b/Tests/PointFreeTests/EpisodePageTests.swift
@@ -572,7 +572,12 @@ class EpisodePageTests: TestCase {
         }
       #endif
 
-      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
+      await withDependencies {
+        $0.episodes = { [episode] }
+        $0.renderHtml = { Html.debugRender($0) }
+      } operation: {
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
+      }
     }
   }
 

--- a/Tests/PointFreeTests/GhostTests.swift
+++ b/Tests/PointFreeTests/GhostTests.swift
@@ -40,7 +40,6 @@ final class GhostTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .admin(.ghost(.start(ghostee.id))), session: adminSession))
       )
-      .performAsync()
 
       await _assertInlineSnapshot(
         matching: conn, as: .conn,
@@ -83,7 +82,6 @@ final class GhostTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .admin(.ghost(.start(ghostee.id))), session: adminSession))
       )
-      .performAsync()
 
       await _assertInlineSnapshot(
         matching: conn, as: .conn,
@@ -128,7 +126,6 @@ final class GhostTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .admin(.ghost(.start(ghostee.id))), session: session))
       )
-      .performAsync()
 
       await _assertInlineSnapshot(
         matching: conn, as: .conn,
@@ -173,7 +170,6 @@ final class GhostTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .endGhosting, session: adminSession))
       )
-      .performAsync()
 
       await _assertInlineSnapshot(
         matching: conn, as: .conn,

--- a/Tests/PointFreeTests/GiftTests.swift
+++ b/Tests/PointFreeTests/GiftTests.swift
@@ -51,10 +51,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -115,10 +115,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -165,10 +165,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -231,10 +231,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts/61F761F7-61F7-61F7-61F7-61F761F761F7
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -293,10 +293,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts/61F761F7-61F7-61F7-61F7-61F761F761F7
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -334,10 +334,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts/61F761F7-61F7-61F7-61F7-61F761F761F7
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -378,10 +378,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts/61F761F7-61F7-61F7-61F7-61F761F761F7
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -426,10 +426,10 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       await _assertInlineSnapshot(
-        matching: result, as: .ioConn,
+        matching: result, as: .conn,
         with: """
           POST http://localhost:8080/gifts/61F761F7-61F7-61F7-61F7-61F761F761F7
           Authorization: Basic aGVsbG86d29ybGQ=
@@ -468,7 +468,7 @@ class GiftTests: TestCase {
         }
       #endif
 
-      await assertSnapshot(matching: siteMiddleware(conn), as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -493,7 +493,7 @@ class GiftTests: TestCase {
         }
       #endif
 
-      await assertSnapshot(matching: siteMiddleware(conn), as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/GiftTests.swift
+++ b/Tests/PointFreeTests/GiftTests.swift
@@ -51,7 +51,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -115,7 +115,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -165,7 +165,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -231,7 +231,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -293,7 +293,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -334,7 +334,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -378,7 +378,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -426,7 +426,7 @@ class GiftTests: TestCase {
           basicAuth: true
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await _assertInlineSnapshot(
         matching: result, as: .conn,
@@ -459,16 +459,16 @@ class GiftTests: TestCase {
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: siteMiddleware(conn),
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2300)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2300)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2300)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2300)),
             ]
           )
         }
       #endif
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -484,16 +484,16 @@ class GiftTests: TestCase {
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: siteMiddleware(conn),
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1100, height: 2300)),
-              "mobile": .ioConnWebView(size: .init(width: 500, height: 2300)),
+              "desktop": .connWebView(size: .init(width: 1100, height: 2300)),
+              "mobile": .connWebView(size: .init(width: 500, height: 2300)),
             ]
           )
         }
       #endif
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/HomeTests.swift
+++ b/Tests/PointFreeTests/HomeTests.swift
@@ -44,14 +44,14 @@ class HomeTests: TestCase {
 
   func testHomepage_LoggedOut() async throws {
     let conn = connection(from: request(to: .home))
-    let result = conn |> siteMiddleware
+    let result = await _siteMiddleware(conn)
 
-    await assertSnapshot(matching: result, as: .ioConn)
+    await assertSnapshot(matching: result, as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: result,
+          matching: siteMiddleware(conn),
           as: [
             "desktop": .ioConnWebView(size: .init(width: 1080, height: 3000)),
             "mobile": .ioConnWebView(size: .init(width: 400, height: 3500)),
@@ -64,7 +64,7 @@ class HomeTests: TestCase {
   func testHomepage_Subscriber() async throws {
     let conn = connection(from: request(to: .home, session: .loggedIn))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -82,6 +82,6 @@ class HomeTests: TestCase {
   func testEpisodesIndex() async throws {
     let conn = connection(from: request(to: .episode(.index)))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 }

--- a/Tests/PointFreeTests/HomeTests.swift
+++ b/Tests/PointFreeTests/HomeTests.swift
@@ -44,17 +44,17 @@ class HomeTests: TestCase {
 
   func testHomepage_LoggedOut() async throws {
     let conn = connection(from: request(to: .home))
-    let result = await _siteMiddleware(conn)
+    let result = await siteMiddleware(conn)
 
     await assertSnapshot(matching: result, as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: siteMiddleware(conn),
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 3000)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 3500)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 3000)),
+            "mobile": .connWebView(size: .init(width: 400, height: 3500)),
           ]
         )
       }
@@ -64,15 +64,15 @@ class HomeTests: TestCase {
   func testHomepage_Subscriber() async throws {
     let conn = connection(from: request(to: .home, session: .loggedIn))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 2300)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 2800)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 2300)),
+            "mobile": .connWebView(size: .init(width: 400, height: 2800)),
           ]
         )
       }
@@ -82,6 +82,6 @@ class HomeTests: TestCase {
   func testEpisodesIndex() async throws {
     let conn = connection(from: request(to: .episode(.index)))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 }

--- a/Tests/PointFreeTests/InviteTests.swift
+++ b/Tests/PointFreeTests/InviteTests.swift
@@ -41,7 +41,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
         session: .init(flash: nil, userId: inviterUser.id)
       )
       let conn = connection(from: sendInvite)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -63,7 +63,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
         session: .init(flash: nil, userId: inviterUser.id))
       let conn = connection(from: sendInvite)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -81,7 +81,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: resendInvite)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 
   func testRevokeInvite_HappyPath() async throws {
@@ -98,7 +98,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: revokeInvite)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     let invite = try? await self.database.fetchTeamInvite(teamInvite.id)
     XCTAssertNil(invite)
@@ -125,7 +125,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: revokeInvite)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     let invite = try? await self.database.fetchTeamInvite(teamInvite.id)
     XCTAssertNotNil(invite)
@@ -155,7 +155,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: acceptInvite)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     // TODO: need `Parallel` to run on main queue during tests, otherwise we can make this assertion.
     // let invite = try? await self.database.fetchTeamInvite(teamInvite.id)
@@ -186,7 +186,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: acceptInvite)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
     XCTAssertNil(subscriptionId, "Current user does not have a subscription")
@@ -219,7 +219,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
       )
       let conn = connection(from: acceptInvite)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
       XCTAssertNil(subscriptionId, "Current user now has a subscription")
@@ -254,7 +254,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
       )
       let conn = connection(from: acceptInvite)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
       XCTAssertNil(subscriptionId, "Current user now has a subscription")
@@ -289,7 +289,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
           )
         )
 
-        await assertSnapshot(matching: siteMiddleware(conn), as: .ioConn)
+        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
         let teamInvites = try await self.database.fetchTeamInvites(currentUser.id)
         XCTAssertEqual(
@@ -325,7 +325,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: resendInvite)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
   }
 }
 
@@ -340,7 +340,7 @@ class InviteTests: TestCase {
     let showInvite = request(to: .invite(.invitation(Models.TeamInvite.mock.id)))
     let conn = connection(from: showInvite)
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -375,7 +375,7 @@ class InviteTests: TestCase {
     } operation: {
       let showInvite = request(to: .invite(.invitation(invite.id)), session: .loggedIn)
       let conn = connection(from: showInvite)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -407,7 +407,7 @@ class InviteTests: TestCase {
     } operation: {
       let showInvite = request(to: .invite(.invitation(invite.id)), session: .loggedIn)
       let conn = connection(from: showInvite)
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/InviteTests.swift
+++ b/Tests/PointFreeTests/InviteTests.swift
@@ -41,7 +41,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
         session: .init(flash: nil, userId: inviterUser.id)
       )
       let conn = connection(from: sendInvite)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -63,7 +63,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
         session: .init(flash: nil, userId: inviterUser.id))
       let conn = connection(from: sendInvite)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -81,7 +81,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: resendInvite)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
   func testRevokeInvite_HappyPath() async throws {
@@ -98,7 +98,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: revokeInvite)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     let invite = try? await self.database.fetchTeamInvite(teamInvite.id)
     XCTAssertNil(invite)
@@ -125,7 +125,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: revokeInvite)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     let invite = try? await self.database.fetchTeamInvite(teamInvite.id)
     XCTAssertNotNil(invite)
@@ -155,7 +155,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: acceptInvite)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     // TODO: need `Parallel` to run on main queue during tests, otherwise we can make this assertion.
     // let invite = try? await self.database.fetchTeamInvite(teamInvite.id)
@@ -186,7 +186,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: acceptInvite)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
     XCTAssertNil(subscriptionId, "Current user does not have a subscription")
@@ -219,7 +219,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
       )
       let conn = connection(from: acceptInvite)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
       XCTAssertNil(subscriptionId, "Current user now has a subscription")
@@ -254,7 +254,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
       )
       let conn = connection(from: acceptInvite)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       let subscriptionId = try await self.database.fetchUserById(currentUser.id).subscriptionId
       XCTAssertNil(subscriptionId, "Current user now has a subscription")
@@ -289,7 +289,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
           )
         )
 
-        await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+        await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
         let teamInvites = try await self.database.fetchTeamInvites(currentUser.id)
         XCTAssertEqual(
@@ -325,7 +325,7 @@ class InviteIntegrationTests: LiveDatabaseTestCase {
     )
     let conn = connection(from: resendInvite)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 }
 
@@ -340,15 +340,15 @@ class InviteTests: TestCase {
     let showInvite = request(to: .invite(.invitation(Models.TeamInvite.mock.id)))
     let conn = connection(from: showInvite)
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 800)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 800)),
+            "mobile": .connWebView(size: .init(width: 400, height: 800)),
           ]
         )
       }
@@ -375,15 +375,15 @@ class InviteTests: TestCase {
     } operation: {
       let showInvite = request(to: .invite(.invitation(invite.id)), session: .loggedIn)
       let conn = connection(from: showInvite)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 800)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 800)),
             ]
           )
         }
@@ -407,7 +407,7 @@ class InviteTests: TestCase {
     } operation: {
       let showInvite = request(to: .invite(.invitation(invite.id)), session: .loggedIn)
       let conn = connection(from: showInvite)
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/InvoicesTests.swift
+++ b/Tests/PointFreeTests/InvoicesTests.swift
@@ -23,7 +23,7 @@ final class InvoicesTests: TestCase {
   func testInvoices() async throws {
     let conn = connection(from: request(to: .account(.invoices()), session: .loggedIn))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -57,7 +57,7 @@ final class InvoicesTests: TestCase {
       let conn = connection(
         from: request(to: .account(.invoices(.show("in_test"))), session: .loggedIn))
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -85,7 +85,7 @@ final class InvoicesTests: TestCase {
       let conn = connection(
         from: request(to: .account(.invoices(.show("in_test"))), session: .loggedIn))
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -113,7 +113,7 @@ final class InvoicesTests: TestCase {
       let conn = connection(
         from: request(to: .account(.invoices(.show("in_test"))), session: .loggedIn))
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {

--- a/Tests/PointFreeTests/InvoicesTests.swift
+++ b/Tests/PointFreeTests/InvoicesTests.swift
@@ -23,15 +23,15 @@ final class InvoicesTests: TestCase {
   func testInvoices() async throws {
     let conn = connection(from: request(to: .account(.invoices()), session: .loggedIn))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 800)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 800)),
+            "mobile": .connWebView(size: .init(width: 400, height: 800)),
           ]
         )
       }
@@ -57,15 +57,15 @@ final class InvoicesTests: TestCase {
       let conn = connection(
         from: request(to: .account(.invoices(.show("in_test"))), session: .loggedIn))
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 800)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 800)),
             ]
           )
         }
@@ -85,15 +85,15 @@ final class InvoicesTests: TestCase {
       let conn = connection(
         from: request(to: .account(.invoices(.show("in_test"))), session: .loggedIn))
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 800)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 800)),
             ]
           )
         }
@@ -113,15 +113,15 @@ final class InvoicesTests: TestCase {
       let conn = connection(
         from: request(to: .account(.invoices(.show("in_test"))), session: .loggedIn))
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 800)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 800)),
             ]
           )
         }

--- a/Tests/PointFreeTests/NewslettersTests.swift
+++ b/Tests/PointFreeTests/NewslettersTests.swift
@@ -51,7 +51,7 @@ class NewslettersIntegrationTests: LiveDatabaseTestCase {
       named: "email_settings_before_unsubscribe"
     )
 
-    let output = await siteMiddleware(connection(from: unsubscribe)).performAsync()
+    let output = await siteMiddleware(connection(from: unsubscribe))
     await assertSnapshot(matching: output, as: .conn)
 
     settings = try await self.database.fetchEmailSettingsForUserId(user.id)
@@ -91,7 +91,7 @@ class NewslettersIntegrationTests: LiveDatabaseTestCase {
         named: "email_settings_before_unsubscribe"
       )
 
-      let output = await siteMiddleware(connection(from: unsubscribe)).performAsync()
+      let output = await siteMiddleware(connection(from: unsubscribe))
       await assertSnapshot(matching: output, as: .conn)
 
       settings = try await self.database.fetchEmailSettingsForUserId(user.id)
@@ -132,7 +132,7 @@ class NewslettersIntegrationTests: LiveDatabaseTestCase {
         named: "email_settings_before_unsubscribe"
       )
 
-      let output = await siteMiddleware(connection(from: unsubscribe)).performAsync()
+      let output = await siteMiddleware(connection(from: unsubscribe))
       await assertSnapshot(matching: output, as: .conn)
 
       settings = try await self.database.fetchEmailSettingsForUserId(user.id)
@@ -177,7 +177,7 @@ class NewslettersIntegrationTests: LiveDatabaseTestCase {
         named: "email_settings_before_unsubscribe"
       )
 
-      let output = await siteMiddleware(connection(from: unsubscribe)).performAsync()
+      let output = await siteMiddleware(connection(from: unsubscribe))
       await assertSnapshot(matching: output, as: .conn)
 
       settings = try await self.database.fetchEmailSettingsForUserId(user.id)

--- a/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
+++ b/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
@@ -25,7 +25,7 @@ final class NotFoundMiddlewareTests: TestCase {
   func testNotFound() async throws {
     let conn = connection(from: URLRequest(url: URL(string: "http://localhost:8080/404")!))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
@@ -54,7 +54,7 @@ final class NotFoundMiddlewareTests: TestCase {
       req.url?.appendPathComponent("404")
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {

--- a/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
+++ b/Tests/PointFreeTests/NotFoundMiddlewareTests.swift
@@ -25,15 +25,15 @@ final class NotFoundMiddlewareTests: TestCase {
   func testNotFound() async throws {
     let conn = connection(from: URLRequest(url: URL(string: "http://localhost:8080/404")!))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 1000)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 1000)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 1000)),
+            "mobile": .connWebView(size: .init(width: 400, height: 1000)),
           ]
         )
       }
@@ -54,15 +54,15 @@ final class NotFoundMiddlewareTests: TestCase {
       req.url?.appendPathComponent("404")
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1000)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1000)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1000)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1000)),
             ]
           )
         }

--- a/Tests/PointFreeTests/PricingLandingTests.swift
+++ b/Tests/PointFreeTests/PricingLandingTests.swift
@@ -30,17 +30,17 @@ class PricingLandingIntegrationTests: LiveDatabaseTestCase {
       $0.database.fetchUserById = { _ in user }
     } operation: {
       let conn = connection(from: request(to: .pricingLanding, session: .loggedIn))
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 4200)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 4700)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 4200)),
+              "mobile": .connWebView(size: .init(width: 400, height: 4700)),
             ]
           )
         }
@@ -63,16 +63,16 @@ class PricingLandingTests: TestCase {
       $0.database.fetchSubscriptionByOwnerId = { _ in .mock }
     } operation: {
       let conn = connection(from: request(to: .pricingLanding, session: .loggedIn))
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 4000)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 4600)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 4000)),
+              "mobile": .connWebView(size: .init(width: 400, height: 4600)),
             ]
           )
         }
@@ -82,17 +82,17 @@ class PricingLandingTests: TestCase {
 
   func testLanding_LoggedOut() async throws {
     let conn = connection(from: request(to: .pricingLanding, session: .loggedOut))
-    let result = await _siteMiddleware(conn)
+    let result = await siteMiddleware(conn)
 
     await assertSnapshot(matching: result, as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 4200)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 4700)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 4200)),
+            "mobile": .connWebView(size: .init(width: 400, height: 4700)),
           ]
         )
       }

--- a/Tests/PointFreeTests/PricingLandingTests.swift
+++ b/Tests/PointFreeTests/PricingLandingTests.swift
@@ -30,9 +30,9 @@ class PricingLandingIntegrationTests: LiveDatabaseTestCase {
       $0.database.fetchUserById = { _ in user }
     } operation: {
       let conn = connection(from: request(to: .pricingLanding, session: .loggedIn))
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -63,8 +63,8 @@ class PricingLandingTests: TestCase {
       $0.database.fetchSubscriptionByOwnerId = { _ in .mock }
     } operation: {
       let conn = connection(from: request(to: .pricingLanding, session: .loggedIn))
-      let result = conn |> siteMiddleware
-      await assertSnapshot(matching: result, as: .ioConn)
+      let result = await _siteMiddleware(conn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -82,9 +82,9 @@ class PricingLandingTests: TestCase {
 
   func testLanding_LoggedOut() async throws {
     let conn = connection(from: request(to: .pricingLanding, session: .loggedOut))
-    let result = conn |> siteMiddleware
+    let result = await _siteMiddleware(conn)
 
-    await assertSnapshot(matching: result, as: .ioConn)
+    await assertSnapshot(matching: result, as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {

--- a/Tests/PointFreeTests/PrivacyTests.swift
+++ b/Tests/PointFreeTests/PrivacyTests.swift
@@ -20,15 +20,15 @@ class PrivacyTests: TestCase {
   func testPrivacy() async throws {
     let conn = connection(from: request(to: .privacy))
 
-    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+    await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {
         await assertSnapshots(
-          matching: conn |> siteMiddleware,
+          matching: await siteMiddleware(conn),
           as: [
-            "desktop": .ioConnWebView(size: .init(width: 1080, height: 1000)),
-            "mobile": .ioConnWebView(size: .init(width: 400, height: 1000)),
+            "desktop": .connWebView(size: .init(width: 1080, height: 1000)),
+            "mobile": .connWebView(size: .init(width: 400, height: 1000)),
           ]
         )
       }

--- a/Tests/PointFreeTests/PrivacyTests.swift
+++ b/Tests/PointFreeTests/PrivacyTests.swift
@@ -20,7 +20,7 @@ class PrivacyTests: TestCase {
   func testPrivacy() async throws {
     let conn = connection(from: request(to: .privacy))
 
-    await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+    await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
 
     #if !os(Linux)
       if self.isScreenshotTestingAvailable {

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -52,7 +52,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -71,7 +71,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -91,7 +91,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -110,7 +110,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -132,7 +132,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -154,7 +154,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -169,7 +169,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -192,7 +192,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       XCTAssertTrue(feedRequestEventCreated)
     }
   }
@@ -215,7 +215,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -237,7 +237,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -257,7 +257,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -277,7 +277,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -296,7 +296,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -318,7 +318,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -340,7 +340,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -356,7 +356,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -381,7 +381,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
       XCTAssertTrue(feedRequestEventCreated)
     }
   }
@@ -404,7 +404,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -428,7 +428,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/PrivateRssTests.swift
+++ b/Tests/PointFreeTests/PrivateRssTests.swift
@@ -52,7 +52,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -71,7 +71,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -91,7 +91,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -110,7 +110,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -132,7 +132,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -154,7 +154,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -169,7 +169,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -192,7 +192,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       XCTAssertTrue(feedRequestEventCreated)
     }
   }
@@ -215,7 +215,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -237,7 +237,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -257,7 +257,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -277,7 +277,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -296,7 +296,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -318,7 +318,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -340,7 +340,7 @@ class PrivateRssTests: TestCase {
           session: .loggedOut
         )
       )
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -356,7 +356,7 @@ class PrivateRssTests: TestCase {
         )
       )
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -381,7 +381,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
       XCTAssertTrue(feedRequestEventCreated)
     }
   }
@@ -404,7 +404,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 
@@ -428,7 +428,7 @@ class PrivateRssTests: TestCase {
 
       let conn = connection(from: req)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/SiteMiddlewareTests.swift
+++ b/Tests/PointFreeTests/SiteMiddlewareTests.swift
@@ -28,14 +28,14 @@ class SiteMiddlewareTests: TestCase {
 
   func testWithoutWWW() async throws {
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: secureRequest("https://pointfree.co"))
       ),
       as: .conn
     )
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: secureRequest("https://pointfree.co/episodes"))
       ),
       as: .conn
@@ -44,14 +44,14 @@ class SiteMiddlewareTests: TestCase {
 
   func testWithoutHeroku() async throws {
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: secureRequest("https://pointfreeco.herokuapp.com"))
       ),
       as: .conn
     )
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: secureRequest("https://pointfreeco.herokuapp.com/episodes"))
       ),
       as: .conn
@@ -60,14 +60,14 @@ class SiteMiddlewareTests: TestCase {
 
   func testWithWWW() async throws {
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: secureRequest("https://www.pointfree.co"))
       ),
       as: .conn
     )
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: secureRequest("https://www.pointfree.co"))
       ),
       as: .conn
@@ -76,7 +76,7 @@ class SiteMiddlewareTests: TestCase {
 
   func testWithHttps() async throws {
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!))
       ),
       as: .conn,
@@ -84,7 +84,7 @@ class SiteMiddlewareTests: TestCase {
     )
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: URLRequest(url: URL(string: "http://www.pointfree.co/episodes")!))
       ),
       as: .conn,
@@ -92,7 +92,7 @@ class SiteMiddlewareTests: TestCase {
     )
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080/")!))
       ),
       as: .conn,
@@ -100,7 +100,7 @@ class SiteMiddlewareTests: TestCase {
     )
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: URLRequest(url: URL(string: "http://127.0.0.1:8080/")!))
       ),
       as: .conn,
@@ -108,7 +108,7 @@ class SiteMiddlewareTests: TestCase {
     )
 
     await assertSnapshot(
-      matching: await _siteMiddleware(
+      matching: await siteMiddleware(
         connection(from: URLRequest(url: URL(string: "http://localhost:8080/")!))
       ),
       as: .conn,

--- a/Tests/PointFreeTests/SiteMiddlewareTests.swift
+++ b/Tests/PointFreeTests/SiteMiddlewareTests.swift
@@ -28,79 +28,90 @@ class SiteMiddlewareTests: TestCase {
 
   func testWithoutWWW() async throws {
     await assertSnapshot(
-      matching: connection(from: secureRequest("https://pointfree.co"))
-        |> siteMiddleware,
-      as: .ioConn
+      matching: await _siteMiddleware(
+        connection(from: secureRequest("https://pointfree.co"))
+      ),
+      as: .conn
     )
 
     await assertSnapshot(
-      matching: connection(from: secureRequest("https://pointfree.co/episodes"))
-        |> siteMiddleware,
-      as: .ioConn
+      matching: await _siteMiddleware(
+        connection(from: secureRequest("https://pointfree.co/episodes"))
+      ),
+      as: .conn
     )
   }
 
   func testWithoutHeroku() async throws {
     await assertSnapshot(
-      matching: connection(from: secureRequest("https://pointfreeco.herokuapp.com"))
-        |> siteMiddleware,
-      as: .ioConn
+      matching: await _siteMiddleware(
+        connection(from: secureRequest("https://pointfreeco.herokuapp.com"))
+      ),
+      as: .conn
     )
 
     await assertSnapshot(
-      matching: connection(from: secureRequest("https://pointfreeco.herokuapp.com/episodes"))
-        |> siteMiddleware,
-      as: .ioConn
+      matching: await _siteMiddleware(
+        connection(from: secureRequest("https://pointfreeco.herokuapp.com/episodes"))
+      ),
+      as: .conn
     )
   }
 
   func testWithWWW() async throws {
     await assertSnapshot(
-      matching: connection(from: secureRequest("https://www.pointfree.co"))
-        |> siteMiddleware,
-      as: .ioConn
+      matching: await _siteMiddleware(
+        connection(from: secureRequest("https://www.pointfree.co"))
+      ),
+      as: .conn
     )
 
     await assertSnapshot(
-      matching: connection(from: secureRequest("https://www.pointfree.co"))
-        |> siteMiddleware,
-      as: .ioConn
+      matching: await _siteMiddleware(
+        connection(from: secureRequest("https://www.pointfree.co"))
+      ),
+      as: .conn
     )
   }
 
   func testWithHttps() async throws {
     await assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!))
-        |> siteMiddleware,
-      as: .ioConn,
+      matching: await _siteMiddleware(
+        connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!))
+      ),
+      as: .conn,
       named: "1.redirects_to_https"
     )
 
     await assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "http://www.pointfree.co/episodes")!))
-        |> siteMiddleware,
-      as: .ioConn,
+      matching: await _siteMiddleware(
+        connection(from: URLRequest(url: URL(string: "http://www.pointfree.co/episodes")!))
+      ),
+      as: .conn,
       named: "2.redirects_to_https"
     )
 
     await assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080/")!))
-        |> siteMiddleware,
-      as: .ioConn,
+      matching: await _siteMiddleware(
+        connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080/")!))
+      ),
+      as: .conn,
       named: "0.0.0.0_allowed"
     )
 
     await assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "http://127.0.0.1:8080/")!))
-        |> siteMiddleware,
-      as: .ioConn,
+      matching: await _siteMiddleware(
+        connection(from: URLRequest(url: URL(string: "http://127.0.0.1:8080/")!))
+      ),
+      as: .conn,
       named: "127.0.0.0_allowed"
     )
 
     await assertSnapshot(
-      matching: connection(from: URLRequest(url: URL(string: "http://localhost:8080/")!))
-        |> siteMiddleware,
-      as: .ioConn,
+      matching: await _siteMiddleware(
+        connection(from: URLRequest(url: URL(string: "http://localhost:8080/")!))
+      ),
+      as: .conn,
       named: "localhost_allowed"
     )
   }

--- a/Tests/PointFreeTests/StripeWebhooksTests.swift
+++ b/Tests/PointFreeTests/StripeWebhooksTests.swift
@@ -326,7 +326,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -341,7 +341,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -352,7 +352,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -374,7 +374,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -399,7 +399,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -421,7 +421,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: conn |> siteMiddleware, as: .ioConn)
+      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -472,7 +472,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
       await _assertInlineSnapshot(
-        matching: conn |> siteMiddleware, as: .ioConn,
+        matching: await _siteMiddleware(conn), as: .conn,
         with: """
           POST http://localhost:8080/webhooks/stripe
           Cookie: pf_session={}
@@ -529,7 +529,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
       await _assertInlineSnapshot(
-        matching: conn |> siteMiddleware, as: .ioConn,
+        matching: await _siteMiddleware(conn), as: .conn,
         with: """
           POST http://localhost:8080/webhooks/stripe
           Cookie: pf_session={}
@@ -583,7 +583,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
       await _assertInlineSnapshot(
-        matching: conn |> siteMiddleware, as: .ioConn,
+        matching: await _siteMiddleware(conn), as: .conn,
         with: """
           POST http://localhost:8080/webhooks/stripe
           Cookie: pf_session={}

--- a/Tests/PointFreeTests/StripeWebhooksTests.swift
+++ b/Tests/PointFreeTests/StripeWebhooksTests.swift
@@ -326,7 +326,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -341,7 +341,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -352,7 +352,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -374,7 +374,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -399,7 +399,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -421,7 +421,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
 
-      await assertSnapshot(matching: await _siteMiddleware(conn), as: .conn)
+      await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
     #endif
   }
 
@@ -472,7 +472,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
       await _assertInlineSnapshot(
-        matching: await _siteMiddleware(conn), as: .conn,
+        matching: await siteMiddleware(conn), as: .conn,
         with: """
           POST http://localhost:8080/webhooks/stripe
           Cookie: pf_session={}
@@ -529,7 +529,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
       await _assertInlineSnapshot(
-        matching: await _siteMiddleware(conn), as: .conn,
+        matching: await siteMiddleware(conn), as: .conn,
         with: """
           POST http://localhost:8080/webhooks/stripe
           Cookie: pf_session={}
@@ -583,7 +583,7 @@ final class StripeWebhooksTests: TestCase {
 
       let conn = connection(from: hook)
       await _assertInlineSnapshot(
-        matching: await _siteMiddleware(conn), as: .conn,
+        matching: await siteMiddleware(conn), as: .conn,
         with: """
           POST http://localhost:8080/webhooks/stripe
           Cookie: pf_session={}

--- a/Tests/PointFreeTests/SubscribeConfirmationTests.swift
+++ b/Tests/PointFreeTests/SubscribeConfirmationTests.swift
@@ -35,17 +35,17 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1400)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1200)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1400)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1200)),
             ]
           )
         }
@@ -66,12 +66,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -97,12 +97,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -130,17 +130,17 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1400)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1400)),
             ]
           )
         }
@@ -169,17 +169,17 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1400)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1400)),
             ]
           )
         }
@@ -208,17 +208,17 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1800)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1400)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1800)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1400)),
             ]
           )
         }
@@ -242,12 +242,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -283,12 +283,13 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -315,7 +316,7 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
     }
@@ -333,17 +334,17 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1400)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1200)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1400)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1200)),
             ]
           )
         }
@@ -359,17 +360,17 @@ class SubscriptionConfirmationTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .discounts(code: "dead-beef", nil), session: .loggedIn))
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1400)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1200)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1400)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1200)),
             ]
           )
         }
@@ -393,12 +394,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -431,17 +432,17 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1400)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1200)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1400)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1200)),
             ]
           )
         }
@@ -463,17 +464,17 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           await assertSnapshots(
-            matching: conn |> siteMiddleware,
+            matching: await siteMiddleware(conn),
             as: [
-              "desktop": .ioConnWebView(size: .init(width: 1080, height: 1400)),
-              "mobile": .ioConnWebView(size: .init(width: 400, height: 1200)),
+              "desktop": .connWebView(size: .init(width: 1080, height: 1400)),
+              "mobile": .connWebView(size: .init(width: 400, height: 1200)),
             ]
           )
         }
@@ -499,7 +500,7 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
     }
@@ -521,7 +522,7 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
     }
@@ -545,7 +546,7 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
     }
@@ -573,7 +574,7 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn(as: user)
         )
       )
-      let result = await _siteMiddleware(conn)
+      let result = await siteMiddleware(conn)
 
       await assertSnapshot(matching: result, as: .conn)
     }

--- a/Tests/PointFreeTests/SubscribeConfirmationTests.swift
+++ b/Tests/PointFreeTests/SubscribeConfirmationTests.swift
@@ -35,9 +35,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -66,12 +66,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: result.performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -97,12 +97,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: result.performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -130,9 +130,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -169,9 +169,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -208,9 +208,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -242,12 +242,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: result.performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -283,12 +283,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: result.performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -315,9 +315,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
     }
   }
 
@@ -333,9 +333,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -359,9 +359,9 @@ class SubscriptionConfirmationTests: TestCase {
     } operation: {
       let conn = connection(
         from: request(to: .discounts(code: "dead-beef", nil), session: .loggedIn))
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -393,12 +393,12 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
           let webView = WKWebView(frame: .init(x: 0, y: 0, width: 1100, height: 1600))
-          let html = await String(decoding: result.performAsync().data, as: UTF8.self)
+          let html = await String(decoding: siteMiddleware(conn).performAsync().data, as: UTF8.self)
           webView.loadHTMLString(html, baseURL: nil)
 
           await assertSnapshot(
@@ -431,9 +431,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -463,9 +463,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
 
       #if !os(Linux)
         if self.isScreenshotTestingAvailable {
@@ -499,9 +499,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
     }
   }
 
@@ -521,9 +521,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
     }
   }
 
@@ -545,9 +545,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedOut
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
     }
   }
 
@@ -573,9 +573,9 @@ class SubscriptionConfirmationTests: TestCase {
           session: .loggedIn(as: user)
         )
       )
-      let result = conn |> siteMiddleware
+      let result = await _siteMiddleware(conn)
 
-      await assertSnapshot(matching: result, as: .ioConn)
+      await assertSnapshot(matching: result, as: .conn)
     }
   }
 }

--- a/Tests/PointFreeTests/SubscribeTests.swift
+++ b/Tests/PointFreeTests/SubscribeTests.swift
@@ -39,7 +39,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
         from: request(to: .subscribe(.some(subscribeData)), session: session)
       )
     )
-    .performAsync()
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -65,7 +64,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
         from: request(to: .subscribe(.some(subscribeData)), session: session)
       )
     )
-    .performAsync()
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -98,7 +96,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
           from: request(to: .subscribe(.some(.individualMonthly)), session: session)
         )
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -137,7 +134,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
           from: request(to: .subscribe(.some(.individualYearly)), session: session)
         )
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -172,7 +168,7 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       to: .subscribe(.some(subscribeData)),
       session: session
     )
-    let conn = await siteMiddleware(connection(from: req)).performAsync()
+    let conn = await siteMiddleware(connection(from: req))
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -208,7 +204,7 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       to: .subscribe(.some(subscribeData)),
       session: session
     )
-    let conn = await siteMiddleware(connection(from: req)).performAsync()
+    let conn = await siteMiddleware(connection(from: req))
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -287,7 +283,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
           from: request(to: .subscribe(subscribeData), session: session)
         )
       )
-      .performAsync()
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
       #endif
@@ -351,7 +346,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: session))
       )
-      .performAsync()
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
       #endif
@@ -409,7 +403,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(.some(subscribeData)), session: session))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -471,7 +464,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(.some(subscribeData)), session: session))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -560,7 +552,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: session))
       )
-      .performAsync()
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
       #endif
@@ -651,7 +642,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: session))
       )
-      .performAsync()
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
       #endif
@@ -690,7 +680,6 @@ final class SubscribeIntegrationTests: LiveDatabaseTestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(.some(subscribeData)), session: session))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -712,7 +701,6 @@ final class SubscribeTests: TestCase {
     let conn = await siteMiddleware(
       connection(from: request(to: .subscribe(.some(.individualMonthly))))
     )
-    .performAsync()
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -735,7 +723,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(.some(subscribeData)), session: session))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -747,7 +734,6 @@ final class SubscribeTests: TestCase {
     let conn = await siteMiddleware(
       connection(from: request(to: .subscribe(.some(.individualYearly))))
     )
-    .performAsync()
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -758,7 +744,6 @@ final class SubscribeTests: TestCase {
     let conn = await siteMiddleware(
       connection(from: request(to: .subscribe(.some(.teamYearly(quantity: 5)))))
     )
-    .performAsync()
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -769,7 +754,6 @@ final class SubscribeTests: TestCase {
     let conn = await siteMiddleware(
       connection(from: request(to: .subscribe(.some(.individualMonthly)), session: .loggedIn))
     )
-    .performAsync()
 
     #if !os(Linux)
       await assertSnapshot(matching: conn, as: .conn)
@@ -787,7 +771,6 @@ final class SubscribeTests: TestCase {
             from: request(to: .subscribe(.some(.teamYearly(quantity: 200))), session: .loggedIn)
           )
         )
-        .performAsync()
 
         await assertSnapshot(matching: conn, as: .conn, named: "too_high")
 
@@ -796,7 +779,6 @@ final class SubscribeTests: TestCase {
             from: request(to: .subscribe(.some(.teamYearly(quantity: 0))), session: .loggedIn)
           )
         )
-        .performAsync()
 
         await assertSnapshot(matching: conn2, as: .conn, named: "too_low")
       }
@@ -812,7 +794,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(.some(.individualMonthly)), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -829,7 +810,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(.some(.individualMonthly)), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -856,7 +836,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -883,7 +862,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -900,7 +878,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(.some(.individualMonthly)), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -927,7 +904,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -953,7 +929,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -980,7 +955,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: .loggedIn))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)
@@ -1011,7 +985,6 @@ final class SubscribeTests: TestCase {
       let conn = await siteMiddleware(
         connection(from: request(to: .subscribe(subscribeData), session: .loggedIn(as: user)))
       )
-      .performAsync()
 
       #if !os(Linux)
         await assertSnapshot(matching: conn, as: .conn)

--- a/Tests/PointFreeTests/__Snapshots__/SubscribeConfirmationTests/testTeam_LoggedIn_AddTeamMember.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/SubscribeConfirmationTests/testTeam_LoggedIn_AddTeamMember.1.Conn.txt
@@ -1,0 +1,2053 @@
+GET http://localhost:8080/subscribe/team?useRegionalDiscount=false
+Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}
+
+200 OK
+Content-Length: 54916
+Content-Type: text/html; charset=utf-8
+Referrer-Policy: strict-origin-when-cross-origin
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: SAMEORIGIN
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Subscribe to Point-Free</title><style>/*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */html{line-height:1.15;-webkit-text-size-adjust:100%}body{margin:0}h1{font-size:2em;margin:.67em 0}hr{box-sizing:content-box;height:0;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}img{border-style:none}button,input,optgroup,select,textarea{font-family:inherit;font-size:100%;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:1px dotted ButtonText}fieldset{padding:.35em .75em .625em}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio]{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details{display:block}summary{display:list-item}template{display:none}[hidden]{display:none}</style><style>
+body, html {
+  height : 100%;
+}
+
+html {
+  font-size          : 14px;
+  font-family        : -apple-system,Helvetica Neue,Helvetica,Arial,sans-serif;
+  line-height        : 1.5;
+  -webkit-box-sizing : border-box;
+  -moz-box-sizing    : border-box;
+  -ms-box-sizing     : border-box;
+  -o-box-sizing      : border-box;
+  box-sizing         : border-box;
+}
+
+body {
+  -webkit-box-sizing : border-box;
+  -moz-box-sizing    : border-box;
+  -ms-box-sizing     : border-box;
+  -o-box-sizing      : border-box;
+  box-sizing         : border-box;
+}
+
+*, *::before, *::after {
+  -webkit-box-sizing : inherit;
+  -moz-box-sizing    : inherit;
+  -ms-box-sizing     : inherit;
+  -o-box-sizing      : inherit;
+  box-sizing         : inherit;
+}
+
+.bg-black {
+  background-color : #121212;
+}
+
+.bg-blue900 {
+  background-color : #e6f8ff;
+}
+
+.bg-dark {
+  background-color : #121212;
+}
+
+.bg-gray150 {
+  background-color : #242424;
+}
+
+.bg-gray650 {
+  background-color : #a8a8a8;
+}
+
+.bg-gray850 {
+  background-color : #d8d8d8;
+}
+
+.bg-gray900 {
+  background-color : #f6f6f6;
+}
+
+.bg-green {
+  background-color : #79f2b0;
+}
+
+.bg-inherit {
+  background-color : inherit;
+}
+
+.bg-purple {
+  background-color : #974dff;
+}
+
+.bg-purple150 {
+  background-color : #291a40;
+}
+
+.bg-red {
+  background-color : #eb1c26;
+}
+
+.bg-white {
+  background-color : #fff;
+}
+
+.bg-yellow {
+  background-color : #fff080;
+}
+
+.border-gray-650 {
+  border-top-color    : #a8a8a8;
+  border-right-color  : #a8a8a8;
+  border-bottom-color : #a8a8a8;
+  border-left-color   : #a8a8a8;
+}
+
+.border-gray-800 {
+  border-top-color    : #ccc;
+  border-right-color  : #ccc;
+  border-bottom-color : #ccc;
+  border-left-color   : #ccc;
+}
+
+.border-gray-850 {
+  border-top-color    : #d8d8d8;
+  border-right-color  : #d8d8d8;
+  border-bottom-color : #d8d8d8;
+  border-left-color   : #d8d8d8;
+}
+
+.border-gray-900 {
+  border-top-color    : #f6f6f6;
+  border-right-color  : #f6f6f6;
+  border-bottom-color : #f6f6f6;
+  border-left-color   : #f6f6f6;
+}
+
+.fg-black {
+  color : #121212;
+}
+
+.fg-blue {
+  color : #4cccff;
+}
+
+.fg-gray300 {
+  color : #555555;
+}
+
+.fg-gray400 {
+  color : #666666;
+}
+
+.fg-gray500 {
+  color : #808080;
+}
+
+.fg-gray650 {
+  color : #a8a8a8;
+}
+
+.fg-gray850 {
+  color : #d8d8d8;
+}
+
+.fg-green {
+  color : #79f2b0;
+}
+
+.fg-purple {
+  color : #974dff;
+}
+
+.fg-red {
+  color : #eb1c26;
+}
+
+.fg-yellow {
+  color : #fff080;
+}
+
+.fg-white {
+  color : #fff;
+}
+
+a:link.pf-link-black {
+  color : #121212;
+}
+
+a:visited.pf-link-black {
+  color : #121212;
+}
+
+a:link.pf-link-gray650 {
+  color : #a8a8a8;
+}
+
+a:visited.pf-link-gray650 {
+  color : #a8a8a8;
+}
+
+a:link.pf-link-green {
+  color : #79f2b0;
+}
+
+a:visited.pf-link-green {
+  color : #79f2b0;
+}
+
+a:link.pf-link-purple {
+  color : #974dff;
+}
+
+a:visited.pf-link-purple {
+  color : #974dff;
+}
+
+a:link.pf-link-red {
+  color : #eb1c26;
+}
+
+a:visited.pf-link-red {
+  color : #eb1c26;
+}
+
+a:link.pf-link-white {
+  color : #fff;
+}
+
+a:visited.pf-link-white {
+  color : #fff;
+}
+
+a:link.pf-link-yellow {
+  color : #fff080;
+}
+
+a:visited.pf-link-yellow {
+  color : #fff080;
+}
+
+.code {
+  background-color : rgba(0,0,0,0.02);
+  color            : #24292e;
+  font-family      : ui-monospace,monospace;
+}
+
+code {
+  font-family : ui-monospace,monospace;
+}
+
+pre {
+  font-family : ui-monospace,monospace;
+}
+
+.inline-code {
+  color                      : #24292e;
+  font-family                : ui-monospace,monospace;
+  padding-top                : 1px;
+  padding-bottom             : 1px;
+  padding-right              : 5px;
+  padding-left               : 5px;
+  border-top-left-radius     : 3px;
+  border-top-right-radius    : 3px;
+  border-bottom-right-radius : 3px;
+  border-bottom-left-radius  : 3px;
+}
+
+.opacity-25 {
+  opacity : 0.25;
+}
+
+.opacity-50 {
+  opacity : 0.5;
+}
+
+.opacity-75 {
+  opacity : 0.75;
+}
+
+a, a:link, a:visited {
+  color           : #121212;
+  text-decoration : none;
+}
+
+a:hover, a:active {
+  text-decoration : underline;
+}
+
+a.underline-link {
+  text-decoration : underline;
+}
+
+.body-leading {
+  font-size : 1.1875rem;
+}
+
+h1, h2, h3, h4, h5, h6, p, ul, ol {
+  margin-top    : 0.5rem;
+  margin-bottom : 0.5rem;
+  margin-right  : 0;
+  margin-left   : 0;
+}
+
+hr {
+  border-top-color    : transparent;
+  border-right-color  : transparent;
+  border-bottom-color : transparent;
+  border-left-color   : transparent;
+  border-top-style    : none;
+  border-right-style  : none;
+  border-bottom-style : none;
+  border-left-style   : none;
+  border-top-width    : 0;
+  border-right-width  : 0;
+  border-bottom-width : 0;
+  border-left-width   : 0;
+}
+
+.pf-divider {
+  border-top-color : #ddd;
+  height           : 0px;
+}
+
+.pf-navbar a, .pf-navbar a:link {
+  color : #fff;
+}
+
+.btn-normal:hover {
+  -webkit-box-shadow : inset 0 0 0 20rem rgba(0,0,0,0.1);
+  -moz-box-shadow    : inset 0 0 0 20rem rgba(0,0,0,0.1);
+  -ms-box-shadow     : inset 0 0 0 20rem rgba(0,0,0,0.1);
+  -o-box-shadow      : inset 0 0 0 20rem rgba(0,0,0,0.1);
+  box-shadow         : inset 0 0 0 20rem rgba(0,0,0,0.1);
+}
+
+a:active.btn-normal {
+  -webkit-box-shadow : inset 0 0 0 20rem rgba(0,0,0,0.3);
+  -moz-box-shadow    : inset 0 0 0 20rem rgba(0,0,0,0.3);
+  -ms-box-shadow     : inset 0 0 0 20rem rgba(0,0,0,0.3);
+  -o-box-shadow      : inset 0 0 0 20rem rgba(0,0,0,0.3);
+  box-shadow         : inset 0 0 0 20rem rgba(0,0,0,0.3);
+}
+
+a:link.btn-normal {
+  text-decoration : none;
+}
+
+.btn-normal {
+  padding-top    : 0.75rem;
+  padding-bottom : 0.75rem;
+}
+
+.btn-outline:hover {
+  text-decoration : none !important;
+}
+
+.btn-outline {
+  text-decoration : underline !important;
+}
+
+.vid-time-link {
+  padding-top : 0.25rem;
+}
+
+.blue-gradient {
+  background : rgba(128,219,255,0.85);
+  background : -moz-linear-gradient(top, rgba(128,219,255,0.85) 0%, rgba(128,219,255,0) 100%);
+  background : -webkit-gradient(left top, left bottom, color-stop(0%, rgba(128,219,255,0.85)), color-stop(100%, rgba(128,219,255,0)));
+  background : -webkit-linear-gradient(top, rgba(128,219,255,0.85) 0%, rgba(128,219,255,0) 100%);
+  background : -o-linear-gradient(top, rgba(128,219,255,0.85) 0%, rgba(128,219,255,0) 100%);
+  background : -ms-linear-gradient(top, rgba(128,219,255,0.85) 0%, rgba(128,219,255,0) 100%);
+  background : linear-gradient(to bottom, rgba(128,219,255,0.85) 0%, rgba(128,219,255,0) 100%);
+}
+
+.reflect-x {
+  transform         : scaleX(-1);
+  -webkit-transform : scaleX(-1);
+  -moz-transform    : scaleX(-1);
+  -o-transform      : scaleX(-1);
+  -ms-transform     : scaleX(-1);
+}
+
+.token.atrule {
+  color       : #d73a49;
+  font-weight : 600;
+}
+
+.token.boolean {
+  color       : #d73a49;
+  font-weight : 600;
+}
+
+.token.builtin {
+  color : #6f42c1;
+}
+
+.token.class-name {
+  color : #6f42c1;
+}
+
+.token.comment {
+  color : #6a737d;
+}
+
+.token.constant {
+  color       : #d73a49;
+  font-weight : 600;
+}
+
+.token.directive-name {
+  color : #643820;
+}
+
+.token.function {
+  color : #005cc5;
+}
+
+.token.keyword {
+  color       : #d73a49;
+  font-weight : 600;
+}
+
+.token.number {
+  color : #a963ff;
+}
+
+.token.string {
+  color : #032f62;
+}
+
+.token.placeholder-open, .placeholder-close {
+  display : none;
+}
+
+.token.placeholder {
+  background-color           : #a8a8a8;
+  border-top-left-radius     : 6px;
+  border-top-right-radius    : 6px;
+  border-bottom-right-radius : 6px;
+  border-bottom-left-radius  : 6px;
+  color                      : #fff;
+  margin-top                 : -2px;
+  margin-bottom              : -2px;
+  margin-right               : -2px;
+  margin-left                : -2px;
+  padding-top                : 2px;
+  padding-bottom             : 2px;
+  padding-right              : 2px;
+  padding-left               : 2px;
+}
+
+.token.code-fold {
+  background-color           : #a8a8a8;
+  border-top-left-radius     : 6px;
+  border-top-right-radius    : 6px;
+  border-bottom-right-radius : 6px;
+  border-bottom-left-radius  : 6px;
+  color                      : #fff;
+  margin-top                 : -2px;
+  margin-bottom              : -2px;
+  margin-right               : -2px;
+  margin-left                : -2px;
+  padding-top                : 2px;
+  padding-bottom             : 2px;
+  padding-right              : 2px;
+  padding-left               : 2px;
+}
+
+.h1 {
+  font-size : 4rem;
+}
+
+.h2 {
+  font-size : 3rem;
+}
+
+.h3 {
+  font-size : 2rem;
+}
+
+.h4 {
+  font-size : 1.5rem;
+}
+
+.h5 {
+  font-size : 1rem;
+}
+
+.h6 {
+  font-size : 0.875rem;
+}
+
+.ts-m-r4 {
+  font-size : 4rem;
+}
+
+.ts-m-r3 {
+  font-size : 3rem;
+}
+
+.ts-m-r2 {
+  font-size : 2rem;
+}
+
+.ts-m-r1_5 {
+  font-size : 1.5rem;
+}
+
+.ts-m-r1_25 {
+  font-size : 1.25rem;
+}
+
+.ts-m-r1 {
+  font-size : 1rem;
+}
+
+.ts-m-r0_875 {
+  font-size : 0.875rem;
+}
+
+.ts-m-r0_75 {
+  font-size : 0.75rem;
+}
+
+.hide-all {
+  position : absolute;
+  height   : 1px;
+  width    : 1px;
+  overflow : hidden;
+  clip     : rect(1px,1px,1px,1px);
+}
+
+.flex {
+  display : flex;
+}
+
+.flex-column {
+  flex-direction : column;
+}
+
+.flex-wrap {
+  flex-wrap : wrap;
+}
+
+
+.items-start {
+  align-items : flex-start;
+}
+
+.items-end {
+  align-items : flex-end;
+}
+
+.items-center {
+  align-items : center;
+}
+
+.items-baseline {
+  align-items : baseline;
+}
+
+.items-stretch {
+  align-items : stretch;
+}
+
+.self-start {
+  align-self : flex-start;
+}
+
+.self-end {
+  align-self : flex-end;
+}
+
+.self-center {
+  align-self : center;
+}
+
+.self-baseline {
+  align-self : baseline;
+}
+
+.self-stretch {
+  align-self : stretch;
+}
+
+.justify-start {
+  justify-content : flex-start;
+}
+
+.justify-end {
+  justify-content : flex-end;
+}
+
+.justify-center {
+  justify-content : center;
+}
+
+.justify-between {
+  justify-content : space-between;
+}
+
+.justify-around {
+  justify-content : space-around;
+}
+
+.align-start {
+  align-content : flex-start;
+}
+
+.align-end {
+  align-content : flex-end;
+}
+
+.align-center {
+  align-content : center;
+}
+
+.align-between {
+  align-content : space-between;
+}
+
+.align-around {
+  align-content : space-around;
+}
+
+.order-0 {
+  order : 0;
+}
+
+.order-1 {
+  order : 1;
+}
+
+.order-2 {
+  order : 2;
+}
+
+.order-3 {
+  order : 3;
+}
+
+.order-last {
+  order : 99999;
+}
+
+.row {
+  -webkit-box-sizing : border-box;
+  -moz-box-sizing    : border-box;
+  -ms-box-sizing     : border-box;
+  -o-box-sizing      : border-box;
+  box-sizing         : border-box;
+  display            : flex;
+  flex-grow          : 0;
+  flex-shrink        : 1;
+  flex-basis         : auto;
+  flex-direction     : row;
+  flex-wrap          : wrap;
+}
+
+.row.reverse {
+  flex-direction : row-reverse;
+}
+
+.col.reverse {
+  flex-direction : column-reverse;
+}
+
+.col-m, .col-m-1, .col-m-2, .col-m-3, .col-m-4, .col-m-5, .col-m-6, .col-m-7, .col-m-8, .col-m-9, .col-m-10, .col-m-11, .col-m-12 {
+  -webkit-box-sizing : border-box;
+  -moz-box-sizing    : border-box;
+  -ms-box-sizing     : border-box;
+  -o-box-sizing      : border-box;
+  box-sizing         : border-box;
+  flex-grow          : 0;
+  flex-shrink        : 0;
+  flex-basis         : auto;
+}
+
+.col-m {
+  flex-grow  : 1;
+  flex-basis : 0;
+  max-width  : 100%;
+}
+
+.col-m-1 {
+  flex-basis : 8.333333333333334%;
+  max-width  : 8.333333333333334%;
+}
+
+.col-m-2 {
+  flex-basis : 16.666666666666668%;
+  max-width  : 16.666666666666668%;
+}
+
+.col-m-3 {
+  flex-basis : 25%;
+  max-width  : 25%;
+}
+
+.col-m-4 {
+  flex-basis : 33.333333333333336%;
+  max-width  : 33.333333333333336%;
+}
+
+.col-m-5 {
+  flex-basis : 41.666666666666664%;
+  max-width  : 41.666666666666664%;
+}
+
+.col-m-6 {
+  flex-basis : 50%;
+  max-width  : 50%;
+}
+
+.col-m-7 {
+  flex-basis : 58.333333333333336%;
+  max-width  : 58.333333333333336%;
+}
+
+.col-m-8 {
+  flex-basis : 66.66666666666667%;
+  max-width  : 66.66666666666667%;
+}
+
+.col-m-9 {
+  flex-basis : 75%;
+  max-width  : 75%;
+}
+
+.col-m-10 {
+  flex-basis : 83.33333333333333%;
+  max-width  : 83.33333333333333%;
+}
+
+.col-m-11 {
+  flex-basis : 91.66666666666667%;
+  max-width  : 91.66666666666667%;
+}
+
+.col-m-12 {
+  flex-basis : 100%;
+  max-width  : 100%;
+}
+
+.start-m {
+  justify-content : flex-start;
+  text-align      : start;
+}
+
+.center-m {
+  justify-content : center;
+  text-align      : center;
+}
+
+.end-m {
+  justify-content : flex-end;
+  text-align      : end;
+}
+
+.top-m {
+  align-items : flex-start;
+}
+
+.middle-m {
+  align-items : center;
+}
+
+.bottom-m {
+  align-items : flex-end;
+}
+
+.around-m {
+  justify-content : space-around;
+}
+
+.between-m {
+  justify-content : space-between;
+}
+
+.first-m {
+  order : -1;
+}
+
+.last-m {
+  order : 1;
+}
+
+.m-pb0 {
+  padding-bottom : 0;
+}
+
+.m-pb1 {
+  padding-bottom : 0.5rem;
+}
+
+.m-pb2 {
+  padding-bottom : 1rem;
+}
+
+.m-pb3 {
+  padding-bottom : 2rem;
+}
+
+.m-pb4 {
+  padding-bottom : 4rem;
+}
+
+.m-pb5 {
+  padding-bottom : 8rem;
+}
+
+.m-pl0 {
+  padding-left : 0;
+}
+
+.m-pl1 {
+  padding-left : 0.5rem;
+}
+
+.m-pl2 {
+  padding-left : 1rem;
+}
+
+.m-pl3 {
+  padding-left : 2rem;
+}
+
+.m-pl4 {
+  padding-left : 4rem;
+}
+
+.m-pl5 {
+  padding-left : 8rem;
+}
+
+.m-pr0 {
+  padding-right : 0;
+}
+
+.m-pr1 {
+  padding-right : 0.5rem;
+}
+
+.m-pr2 {
+  padding-right : 1rem;
+}
+
+.m-pr3 {
+  padding-right : 2rem;
+}
+
+.m-pr4 {
+  padding-right : 4rem;
+}
+
+.m-pr5 {
+  padding-right : 8rem;
+}
+
+.m-pt0 {
+  padding-top : 0;
+}
+
+.m-pt1 {
+  padding-top : 0.5rem;
+}
+
+.m-pt2 {
+  padding-top : 1rem;
+}
+
+.m-pt3 {
+  padding-top : 2rem;
+}
+
+.m-pt4 {
+  padding-top : 4rem;
+}
+
+.m-pt5 {
+  padding-top : 8rem;
+}
+
+.m-mb0 {
+  margin-bottom : 0;
+}
+
+.m-mb1 {
+  margin-bottom : 0.5rem;
+}
+
+.m-mb2 {
+  margin-bottom : 1rem;
+}
+
+.m-mb3 {
+  margin-bottom : 2rem;
+}
+
+.m-mb4 {
+  margin-bottom : 4rem;
+}
+
+.m-mb5 {
+  margin-bottom : 8rem;
+}
+
+.m-ml0 {
+  margin-left : 0;
+}
+
+.m-ml1 {
+  margin-left : 0.5rem;
+}
+
+.m-ml2 {
+  margin-left : 1rem;
+}
+
+.m-ml3 {
+  margin-left : 2rem;
+}
+
+.m-ml4 {
+  margin-left : 4rem;
+}
+
+.m-ml5 {
+  margin-left : 8rem;
+}
+
+.m-mr0 {
+  margin-right : 0;
+}
+
+.m-mr1 {
+  margin-right : 0.5rem;
+}
+
+.m-mr2 {
+  margin-right : 1rem;
+}
+
+.m-mr3 {
+  margin-right : 2rem;
+}
+
+.m-mr4 {
+  margin-right : 4rem;
+}
+
+.m-mr5 {
+  margin-right : 8rem;
+}
+
+.m-mt0 {
+  margin-top : 0;
+}
+
+.m-mt1 {
+  margin-top : 0.5rem;
+}
+
+.m-mt2 {
+  margin-top : 1rem;
+}
+
+.m-mt3 {
+  margin-top : 2rem;
+}
+
+.m-mt4 {
+  margin-top : 4rem;
+}
+
+.m-mt5 {
+  margin-top : 8rem;
+}
+
+.bold {
+  font-weight : 700;
+}
+
+.bolder {
+  font-weight : bolder;
+}
+
+.medium {
+  font-weight : 500;
+}
+
+.semi-bold {
+  font-weight : 600;
+}
+
+.caps {
+  text-transform : uppercase;
+  letter-spacing : 0.54pt;
+}
+
+.italic {
+  font-style : italic;
+}
+
+.light {
+  font-weight : 300;
+}
+
+.lighter {
+  font-weight : light;
+}
+
+.normal {
+  font-weight : normal;
+}
+
+.underline {
+  text-decoration : underline;
+}
+
+.lh-0 {
+  line-height : 1.15;
+}
+
+.lh-1 {
+  line-height : 1.25;
+}
+
+.lh-2 {
+  line-height : 1.45;
+}
+
+.lh-3 {
+  line-height : 1.5;
+}
+
+.lh-1r {
+  line-height : 1rem;
+}
+
+.lh-2r {
+  line-height : 2rem;
+}
+
+.lh-3r {
+  line-height : 3rem;
+}
+
+.lh-4r {
+  line-height : 4rem;
+}
+
+.font-family-inherit {
+  font-family : inherit;
+}
+
+.font-family-monospace {
+  font-family : ui-monospace,monospace;
+}
+
+.font-size-inherit {
+  font-size : inherit;
+}
+
+.text-decoration-none {
+  text-decoration : none;
+}
+
+.list-style-none {
+  list-style-type : none;
+}
+
+.list-reset {
+  list-style-type : none;
+  padding-left    : 0;
+}
+
+.start-align {
+  text-align : start;
+}
+
+.center {
+  text-align : center;
+}
+
+.end-align {
+  text-align : end;
+}
+
+.justify {
+  text-align : justify;
+}
+
+.nowrap {
+  white-space : nowrap;
+}
+
+.break-word {
+  word-wrap : break-word;
+}
+
+.overflow-hidden {
+  overflow : hidden;
+}
+
+.overflow-scroll {
+  overflow : scroll;
+}
+
+.overflow-auto {
+  overflow : auto;
+}
+
+.overflow-auto-x {
+  overflow-x : auto;
+}
+
+.overflow-auto-y {
+  overflow-y : auto;
+}
+
+.clear-fix::before, .clear-fix::after {
+  content : "";
+  display : table;
+}
+
+.clear-fix::after {
+  clear : both;
+}
+
+.left {
+  float : left;
+}
+
+.right {
+  float : right;
+}
+
+.fit {
+  max-width : 100%;
+}
+
+.border-box {
+  -webkit-box-sizing : border-box;
+  -moz-box-sizing    : border-box;
+  -ms-box-sizing     : border-box;
+  -o-box-sizing      : border-box;
+  box-sizing         : border-box;
+}
+
+.static {
+  position : static;
+}
+
+.relative {
+  position : relative;
+}
+
+.absolute {
+  position : absolute;
+}
+
+.fixed {
+  position : fixed;
+}
+
+.sticky {
+  position : sticky;
+  position : -webkit-sticky;
+}
+
+.sticky-m {
+  position : sticky;
+  position : -webkit-sticky;
+}
+
+.top-0 {
+  top : 0;
+}
+
+.right-0 {
+  right : 0;
+}
+
+.bottom-0 {
+  bottom : 0;
+}
+
+.left-0 {
+  left : 0;
+}
+
+.z1 {
+  z-index : 1;
+}
+
+.z2 {
+  z-index : 2;
+}
+
+.z3 {
+  z-index : 3;
+}
+
+.z4 {
+  z-index : 4;
+}
+
+.far-far-away {
+  position : absolute;
+  top      : -9999px;
+  left     : -9999px;
+}
+
+.border {
+  border-top-style    : solid;
+  border-right-style  : solid;
+  border-bottom-style : solid;
+  border-left-style   : solid;
+  border-top-width    : 1px;
+  border-right-width  : 1px;
+  border-bottom-width : 1px;
+  border-left-width   : 1px;
+}
+
+.border-top {
+  border-top-style : solid;
+  border-top-width : 1px;
+}
+
+.border-right {
+  border-right-style : solid;
+  border-right-width : 1px;
+}
+
+.border-bottom {
+  border-bottom-style : solid;
+  border-bottom-width : 1px;
+}
+
+.border-left {
+  border-left-style : solid;
+  border-left-width : 1px;
+}
+
+.border-none {
+  border-top-style    : none;
+  border-right-style  : none;
+  border-bottom-style : none;
+  border-left-style   : none;
+  border-top-width    : 0;
+  border-right-width  : 0;
+  border-bottom-width : 0;
+  border-left-width   : 0;
+}
+
+.rounded {
+  border-top-left-radius     : 6px;
+  border-top-right-radius    : 6px;
+  border-bottom-right-radius : 6px;
+  border-bottom-left-radius  : 6px;
+}
+
+.rounded-left {
+  border-top-left-radius    : 6px;
+  border-bottom-left-radius : 6px;
+}
+
+.rounded-right {
+  border-top-right-radius    : 6px;
+  border-bottom-right-radius : 6px;
+}
+
+.circle {
+  border-top-left-radius     : 50%;
+  border-top-right-radius    : 50%;
+  border-bottom-right-radius : 50%;
+  border-bottom-left-radius  : 50%;
+}
+
+.pill {
+  border-top-left-radius     : 9999px;
+  border-top-right-radius    : 9999px;
+  border-bottom-right-radius : 9999px;
+  border-bottom-left-radius  : 9999px;
+}
+
+.align-middle {
+  vertical-align : middle;
+}
+
+.align-top {
+  vertical-align : top;
+}
+
+.h-1r {
+  height : 1rem;
+}
+
+.h-2r {
+  height : 2rem;
+}
+
+.h-3r {
+  height : 3rem;
+}
+
+.h-4r {
+  height : 4rem;
+}
+
+.w-50p {
+  width : 50%;
+}
+
+.w-100p {
+  width : 100%;
+}
+
+.h-100p {
+  height : 100%;
+}
+
+.inline {
+  display : inline;
+}
+
+.block {
+  display : block;
+}
+
+.inline-block {
+  display : inline-block;
+}
+
+.none {
+  display : none;
+}
+
+.table {
+  display : table;
+}
+
+.table-cell {
+  display : table-cell;
+}
+
+.cursor-pointer {
+  cursor : pointer;
+}
+
+@media only screen and (min-width: 832px) {
+
+html {
+  font-size : 16px;
+}
+
+}
+@media only screen and (max-width: 831px) {
+
+.hero-logo {
+  max-width : 260px;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.ts-d-r4 {
+  font-size : 4rem;
+}
+
+.ts-d-r3 {
+  font-size : 3rem;
+}
+
+.ts-d-r2 {
+  font-size : 2rem;
+}
+
+.ts-d-r1_5 {
+  font-size : 1.5rem;
+}
+
+.ts-d-r1_25 {
+  font-size : 1.25rem;
+}
+
+.ts-d-r1 {
+  font-size : 1rem;
+}
+
+.ts-d-r0_875 {
+  font-size : 0.875rem;
+}
+
+.ts-d-r0_75 {
+  font-size : 0.75rem;
+}
+
+}
+@media only screen and (max-width: 831px) {
+
+.hide-m {
+  display : none;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.hide-d {
+  display : none;
+}
+
+}
+@media only screen and (max-width: 831px) {
+
+.flex-m {
+  display : flex;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.flex-d {
+  display : flex;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.col-d, .col-d-1, .col-d-2, .col-d-3, .col-d-4, .col-d-5, .col-d-6, .col-d-7, .col-d-8, .col-d-9, .col-d-10, .col-d-11, .col-d-12 {
+  -webkit-box-sizing : border-box;
+  -moz-box-sizing    : border-box;
+  -ms-box-sizing     : border-box;
+  -o-box-sizing      : border-box;
+  box-sizing         : border-box;
+  flex-grow          : 0;
+  flex-shrink        : 0;
+  flex-basis         : auto;
+}
+
+.col-d {
+  flex-grow  : 1;
+  flex-basis : 0;
+  max-width  : 100%;
+}
+
+.col-d-1 {
+  flex-basis : 8.333333333333334%;
+  max-width  : 8.333333333333334%;
+}
+
+.col-d-2 {
+  flex-basis : 16.666666666666668%;
+  max-width  : 16.666666666666668%;
+}
+
+.col-d-3 {
+  flex-basis : 25%;
+  max-width  : 25%;
+}
+
+.col-d-4 {
+  flex-basis : 33.333333333333336%;
+  max-width  : 33.333333333333336%;
+}
+
+.col-d-5 {
+  flex-basis : 41.666666666666664%;
+  max-width  : 41.666666666666664%;
+}
+
+.col-d-6 {
+  flex-basis : 50%;
+  max-width  : 50%;
+}
+
+.col-d-7 {
+  flex-basis : 58.333333333333336%;
+  max-width  : 58.333333333333336%;
+}
+
+.col-d-8 {
+  flex-basis : 66.66666666666667%;
+  max-width  : 66.66666666666667%;
+}
+
+.col-d-9 {
+  flex-basis : 75%;
+  max-width  : 75%;
+}
+
+.col-d-10 {
+  flex-basis : 83.33333333333333%;
+  max-width  : 83.33333333333333%;
+}
+
+.col-d-11 {
+  flex-basis : 91.66666666666667%;
+  max-width  : 91.66666666666667%;
+}
+
+.col-d-12 {
+  flex-basis : 100%;
+  max-width  : 100%;
+}
+
+.start-d {
+  justify-content : flex-start;
+  text-align      : start;
+}
+
+.center-d {
+  justify-content : center;
+  text-align      : center;
+}
+
+.end-d {
+  justify-content : flex-end;
+  text-align      : end;
+}
+
+.top-d {
+  align-items : flex-start;
+}
+
+.middle-d {
+  align-items : center;
+}
+
+.bottom-d {
+  align-items : flex-end;
+}
+
+.around-d {
+  justify-content : space-around;
+}
+
+.between-d {
+  justify-content : space-between;
+}
+
+.first-d {
+  order : -1;
+}
+
+.last-d {
+  order : 1;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.d-pb0 {
+  padding-bottom : 0;
+}
+
+.d-pb1 {
+  padding-bottom : 0.5rem;
+}
+
+.d-pb2 {
+  padding-bottom : 1rem;
+}
+
+.d-pb3 {
+  padding-bottom : 2rem;
+}
+
+.d-pb4 {
+  padding-bottom : 4rem;
+}
+
+.d-pb5 {
+  padding-bottom : 8rem;
+}
+
+.d-pl0 {
+  padding-left : 0;
+}
+
+.d-pl1 {
+  padding-left : 0.5rem;
+}
+
+.d-pl2 {
+  padding-left : 1rem;
+}
+
+.d-pl3 {
+  padding-left : 2rem;
+}
+
+.d-pl4 {
+  padding-left : 4rem;
+}
+
+.d-pl5 {
+  padding-left : 8rem;
+}
+
+.d-pr0 {
+  padding-right : 0;
+}
+
+.d-pr1 {
+  padding-right : 0.5rem;
+}
+
+.d-pr2 {
+  padding-right : 1rem;
+}
+
+.d-pr3 {
+  padding-right : 2rem;
+}
+
+.d-pr4 {
+  padding-right : 4rem;
+}
+
+.d-pr5 {
+  padding-right : 8rem;
+}
+
+.d-pt0 {
+  padding-top : 0;
+}
+
+.d-pt1 {
+  padding-top : 0.5rem;
+}
+
+.d-pt2 {
+  padding-top : 1rem;
+}
+
+.d-pt3 {
+  padding-top : 2rem;
+}
+
+.d-pt4 {
+  padding-top : 4rem;
+}
+
+.d-pt5 {
+  padding-top : 8rem;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.d-mb0 {
+  margin-bottom : 0;
+}
+
+.d-mb1 {
+  margin-bottom : 0.5rem;
+}
+
+.d-mb2 {
+  margin-bottom : 1rem;
+}
+
+.d-mb3 {
+  margin-bottom : 2rem;
+}
+
+.d-mb4 {
+  margin-bottom : 4rem;
+}
+
+.d-mb5 {
+  margin-bottom : 8rem;
+}
+
+.d-ml0 {
+  margin-left : 0;
+}
+
+.d-ml1 {
+  margin-left : 0.5rem;
+}
+
+.d-ml2 {
+  margin-left : 1rem;
+}
+
+.d-ml3 {
+  margin-left : 2rem;
+}
+
+.d-ml4 {
+  margin-left : 4rem;
+}
+
+.d-ml5 {
+  margin-left : 8rem;
+}
+
+.d-mr0 {
+  margin-right : 0;
+}
+
+.d-mr1 {
+  margin-right : 0.5rem;
+}
+
+.d-mr2 {
+  margin-right : 1rem;
+}
+
+.d-mr3 {
+  margin-right : 2rem;
+}
+
+.d-mr4 {
+  margin-right : 4rem;
+}
+
+.d-mr5 {
+  margin-right : 8rem;
+}
+
+.d-mt0 {
+  margin-top : 0;
+}
+
+.d-mt1 {
+  margin-top : 0.5rem;
+}
+
+.d-mt2 {
+  margin-top : 1rem;
+}
+
+.d-mt3 {
+  margin-top : 2rem;
+}
+
+.d-mt4 {
+  margin-top : 4rem;
+}
+
+.d-mt5 {
+  margin-top : 8rem;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.sticky-d {
+  position : sticky;
+  position : -webkit-sticky;
+}
+
+}
+</style><style>
+
+.md-ctn hr {
+  margin-top       : 2rem;
+  margin-right     : 30%;
+  margin-bottom    : 2rem;
+  margin-left      : 30%;
+  border-top-style : solid;
+  border-top-width : 1px;
+  background-color : #ffffff;
+  border-top-color : #ddd;
+  height           : 0px;
+}
+
+.md-ctn a {
+  text-decoration : underline;
+}
+
+.md-ctn a:link {
+  color : #291a40;
+}
+
+.md-ctn a:visited {
+  color : #291a40;
+}
+
+.md-ctn a:hover {
+  color : #121212;
+}
+
+.md-ctn ul {
+  margin-bottom : 1.5rem;
+}
+
+.md-ctn blockquote {
+  color                      : #555555;
+  border-left-color          : #d8d8d8;
+  border-top-left-radius     : 2px;
+  border-top-right-radius    : 2px;
+  border-bottom-right-radius : 2px;
+  border-bottom-left-radius  : 2px;
+  border-left-style          : solid;
+  border-left-width          : 3px;
+  margin-right               : 0rem;
+  margin-bottom              : 2rem;
+  margin-left                : 0rem;
+  padding-right              : 2rem;
+  padding-left               : 2rem;
+}
+
+.md-ctn p {
+  word-wrap : break-word;
+}
+
+.md-ctn p:not(:last-child) {
+  margin-bottom : 1.5rem;
+}
+
+
+.md-ctn pre code {
+  padding-top                : 0.5rem;
+  padding-bottom             : 0.5rem;
+  padding-right              : 2rem;
+  padding-left               : 2rem;
+  background-color           : rgba(0,0,0,0.02);
+  border-top-color           : rgba(0,0,0,0.15);
+  border-right-color         : rgba(0,0,0,0.15);
+  border-bottom-color        : rgba(0,0,0,0.15);
+  border-left-color          : rgba(0,0,0,0.15);
+  border-top-left-radius     : 6px;
+  border-top-right-radius    : 6px;
+  border-bottom-right-radius : 6px;
+  border-bottom-left-radius  : 6px;
+  display                    : block;
+  margin-bottom              : 1.5rem;
+}
+
+.md-ctn pre {
+  overflow-x : auto;
+}
+
+.md-ctn code {
+  font-family : ui-monospace,monospace;
+}
+
+.pricing-plan-feature > p {
+  margin-top    : 0;
+  margin-right  : 0;
+  margin-bottom : 0;
+  margin-left   : 0;
+}
+
+.plan-item {
+  width : 100%;
+}
+
+.testimonial-container {
+  height                     : 380px;
+  -webkit-overflow-scrolling : touch;
+}
+
+.testimonial-item {
+  flex-grow   : 0;
+  flex-shrink : 0;
+  flex-basis  : auto;
+  width       : 260px;
+  height      : 380px;
+}
+
+@media only screen and (min-width: 832px) {
+
+.dark-right-border-d {
+  border-right : 1px solid #333;
+}
+
+.light-right-border-d {
+  border-right : 1px solid #e8e8e8;
+}
+
+.light-bottom-border-d {
+  border-bottom : 1px solid #e8e8e8;
+}
+
+.plan-item {
+  width : 25%;
+}
+
+}
+@media only screen and (min-width: 832px) {
+
+.testimonial-container {
+  height : 400px;
+}
+
+.testimonial-item {
+  width : 340px;
+}
+
+.testimonial-item {
+  height : 380px;
+}
+
+}
+</style><meta name="viewport" content="width=device-width,initial-scale=1.0"><link href="http://localhost:8080/feed/episodes.xml" rel="alternate" title="Point-Free Episodes" type="application/atom+xml"><link href="http://localhost:8080/blog/feed/atom.xml" rel="alternate" title="Point-Free Blog" type="application/atom+xml"><link rel="apple-touch-icon" sizes="180x180" href="https://d3rccdn33rt8ze.cloudfront.net/favicons/apple-touch-icon.png"><link rel="icon" type="image/png" sizes="32x32" href="https://d3rccdn33rt8ze.cloudfront.net/favicons/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="https://d3rccdn33rt8ze.cloudfront.net/favicons/favicon-16x16.png"><link rel="manifest" href="https://d3rccdn33rt8ze.cloudfront.net/favicons/site.webmanifest"><link rel="mask-icon" href="https://d3rccdn33rt8ze.cloudfront.net/favicons/safari-pinned-tab.svg"><meta name="description" content="Point-Free is a video series exploring functional programming and Swift."><meta property="og:description" content="Point-Free is a video series exploring functional programming and Swift."><meta name="twitter:description" content="Point-Free is a video series exploring functional programming and Swift."><meta name="twitter:image" content="https://d3rccdn33rt8ze.cloudfront.net/social-assets/twitter-card-large.png"><meta property="og:image" content="https://d3rccdn33rt8ze.cloudfront.net/social-assets/twitter-card-large.png"><meta name="title" content="Subscribe to Point-Free"><meta property="og:title" content="Subscribe to Point-Free"><meta name="twitter:title" content="Subscribe to Point-Free"><meta property="og:type" content="website"><meta name="twitter:card" content="summary_large_image"><meta name="twitter:site" content="@pointfreeco"><meta property="og:url" content="http://localhost:8080/subscribe/team?useRegionalDiscount=false"><meta name="twitter:url" content="http://localhost:8080/subscribe/team?useRegionalDiscount=false"><script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create', 'UA-106218876-1', 'auto');ga('send', 'pageview');</script></head><body><div class="bg-black d-pt2 d-pb2 m-pl2 m-pr2 m-pt2 m-pb2 middle-m between-m"><div style="max-width:1080px;margin-right:auto;margin-left:auto"><div class="items-center row"><div class="hide-d col-m"><a class="start-m" href="/"><img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNzJweCIgaGVpZ2h0PSI3MnB4IiB2aWV3Qm94PSIwIDAgNzIgNzIiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iR3JvdXAiIGZpbGw9IiNmZmZmZmYiPgogICAgICAgICAgICA8cGF0aCBkPSJNNTQuMzM2MzI4Niw1My42NjM2NzE0IEwzNiw3MiBMMTcuNjYzNjcxNCw1My42NjM2NzE0IEwxOC4xMTkxMTg2LDUzLjY2MzY3MTQgTDE4LjExOTExODYsNDkuNjkxMjY2MSBMMjIuNjM3NDkzLDQ5LjY5MTI2NjEgTDIyLjYzNzQ5Myw0Ni44Nzc0Nzg5IEwxOC4xMTkxMTg2LDQ2Ljg3NzQ3ODkgTDE4LjExOTExODYsNDMuOTcxNzM4IEwyMy4yNDExNjI1LDQzLjk3MTczOCBMMjMuMjQxMTYyNSw0MS4xNTc5NTA5IEwxNC43ODk3OTAxLDQxLjE1Nzk1MDkgTDE0Ljc4OTc5MDEsNTAuNzg5NzkwMSBMMi4xMzE2MjgyMWUtMTQsMzYgTDcuNzk3Mjg1NTksMjguMjAyNzE0NCBMNy43OTcyODU1OSwzNS4yNzI5MDU5IEwxMS4xMjY2MTQxLDM1LjI3MjkwNTkgTDExLjEyNjYxNDEsMzIuNTY5NDYzNCBMMTIuNTE2ODgzMSwzMi41Njk0NjM0IEMxNS44NjQ1MDQ3LDMyLjU2OTQ2MzQgMTcuNzQ4Njg1MSwzMC40NTQ1MjU0IDE3Ljc0ODY4NTEsMjcuNjc3NTE5OCBDMTcuNzQ4Njg1MSwyNS4wOTU5MTI5IDE2LjEyMDMyOTcsMjMuMDcwNTg3NSAxMy4yMDE2NDc0LDIyLjc5ODM1MjYgTDM2LDIuMTMxNjI4MjFlLTE0IEw1OC43NjcxODU0LDIyLjc2NzE4NTQgTDU0LjI5ODEyNjcsMjIuNzY3MTg1NCBMNTQuMjk4MTI2NywyNS41ODA5NzI1IEw1Ny41OTA4NjkxLDI1LjU4MDk3MjUgTDU3LjU5MDg2OTEsMzUuMjcyOTA1OSBMNjAuOTIwMTk3NiwzNS4yNzI5MDU5IEw2MC45MjAxOTc2LDI1LjU4MDk3MjUgTDYxLjU4MDk3MjUsMjUuNTgwOTcyNSBMNzIsMzYgTDU3LjE1MDExNTcsNTAuODQ5ODg0MyBMNTIuMDI5NzkyOSw1MC44NDk4ODQzIEw1Mi4wMjk3OTI5LDQ5LjU0NDEzOTkgTDU2LjUyOTg3NDMsNDkuNTQ0MTM5OSBMNTYuNTI5ODc0Myw0Ni44Nzc0Nzg5IEw1Mi4wMjk3OTI5LDQ2Ljg3NzQ3ODkgTDUyLjAyOTc5MjksNDMuOTcxNzM4IEw1Ny40MjYyMzIsNDMuOTcxNzM4IEw1Ny40MjYyMzIsNDEuMTU3OTUwOSBMNDguNzAwNDY0NCw0MS4xNTc5NTA5IEw0OC43MDA0NjQ0LDUzLjY2MzY3MTQgTDU0LjMzNjMyODYsNTMuNjYzNjcxNCBaIE0xMS4xMjY2MTQxLDI5LjczNzI4NTUgTDExLjEyNjYxNDEsMjUuNTk5MzYzMyBMMTIuMzUyMjQ2LDI1LjU5OTM2MzMgQzEzLjg1MjI3MzIsMjUuNTk5MzYzMyAxNC40MDEwNjM2LDI2LjQ2MzcyOTMgMTQuNDAxMDYzNiwyNy42Nzc1MTk4IEMxNC40MDEwNjM2LDI4Ljg5MTMxMDMgMTMuODUyMjczMiwyOS43MzcyODU1IDEyLjM1MjI0NiwyOS43MzcyODU1IEwxMS4xMjY2MTQxLDI5LjczNzI4NTUgWiBNMjYuMDIxNzAwNiwzNS40Mzg0MjI4IEMyOS42MDcxMzEzLDM1LjQzODQyMjggMzIuNjk4NjUwNiwzMi43OTAxNTI2IDMyLjY5ODY1MDYsMjkuMDIwMDQ1NyBDMzIuNjk4NjUwNiwyNS4yNDk5Mzg3IDI5LjYwNzEzMTMsMjIuNjIwMDU5MyAyNi4wMjE3MDA2LDIyLjYyMDA1OTMgQzIyLjQzNjI2OTksMjIuNjIwMDU5MyAxOS4zNDQ3NTA1LDI1LjI0OTkzODcgMTkuMzQ0NzUwNSwyOS4wMjAwNDU3IEMxOS4zNDQ3NTA1LDMyLjc5MDE1MjYgMjIuNDM2MjY5OSwzNS40Mzg0MjI4IDI2LjAyMTcwMDYsMzUuNDM4NDIyOCBaIE0yNi4wMjE3MDA2LDMyLjUzMjY4MTkgQzIzLjkzNjI5NywzMi41MzI2ODE5IDIyLjc0NzI1MTEsMzAuOTg3ODU3NiAyMi43NDcyNTExLDI5LjAyMDA0NTcgQzIyLjc0NzI1MTEsMjcuMDUyMjMzOCAyMy45MzYyOTcsMjUuNTI1ODAwMiAyNi4wMjE3MDA2LDI1LjUyNTgwMDIgQzI4LjEwNzEwNDIsMjUuNTI1ODAwMiAyOS4yOTYxNSwyNy4wNTIyMzM4IDI5LjI5NjE1LDI5LjAyMDA0NTcgQzI5LjI5NjE1LDMwLjk4Nzg1NzYgMjguMTA3MTA0MiwzMi41MzI2ODE5IDI2LjAyMTcwMDYsMzIuNTMyNjgxOSBaIE0zNC44OTgzODU1LDM1LjI3MjkwNTkgTDM4LjIyNzcxNCwzNS4yNzI5MDU5IEwzOC4yMjc3MTQsMjIuNzY3MTg1NCBMMzQuODk4Mzg1NSwyMi43NjcxODU0IEwzNC44OTgzODU1LDM1LjI3MjkwNTkgWiBNNTEuOTcwMzQwNiwzNS40OTM1OTUxIEM1Mi4xNzE1NjM4LDM1LjY1OTExMiA1Mi4yMjY0NDI4LDM1LjYwMzkzOTcgNTIuMjI2NDQyOCwzNS40NTY4MTM2IEw1Mi4yMjY0NDI4LDIyLjc2NzE4NTQgTDQ5LjA5ODMzNzUsMjIuNzY3MTg1NCBMNDkuMDk4MzM3NSwyOS4wMzg0MzY0IEw0MS4yODcyMjA2LDIyLjU2NDg4NyBDNDEuMDg1OTk3NCwyMi4zOTkzNzAxIDQxLjAzMTExODQsMjIuNDkxMzIzOSA0MS4wMzExMTg0LDIyLjYwMTY2ODUgTDQxLjAzMTExODQsMzUuMjcyOTA1OSBMNDQuMTU5MjIzOCwzNS4yNzI5MDU5IEw0NC4xNTkyMjM4LDI5LjAzODQzNjQgTDUxLjk3MDM0MDYsMzUuNDkzNTk1MSBaIE0zMy4xNjA1NDkyLDUwLjExNDI1MzcgQzM0LjYyMzk5MDMsNDkuMzA1MDYgMzUuNDEwNTg5OSw0Ny44NzA1ODAzIDM1LjQxMDU4OTksNDYuMDY4Mjg1MyBDMzUuNDEwNTg5OSw0My4yOTEyNzk3IDMzLjUyNjQwOTUsNDEuMTU3OTUwOSAzMC4xNzg3ODgsNDEuMTU3OTUwOSBMMjUuNDU5MTkwNCw0MS4xNTc5NTA5IEwyNS40NTkxOTA0LDUzLjY2MzY3MTQgTDI4Ljc4ODUxODksNTMuNjYzNjcxNCBMMjguNzg4NTE4OSw1MC43OTQ3MTIgTDMwLjAzMjQ0MzksNTAuNzk0NzEyIEwzMS43NzAyODAyLDUzLjY2MzY3MTQgTDM1LjM3NDAwMzksNTMuNjYzNjcxNCBMMzMuMTYwNTQ5Miw1MC4xMTQyNTM3IFogTTI4Ljc4ODUxODksNDguMTI4MDUxIEwyOC43ODg1MTg5LDQzLjk5MDEyODggTDMwLjAxNDE1MDgsNDMuOTkwMTI4OCBDMzEuNTE0MTc4LDQzLjk5MDEyODggMzIuMDYyOTY4NCw0NC44NTQ0OTQ3IDMyLjA2Mjk2ODQsNDYuMDY4Mjg1MyBDMzIuMDYyOTY4NCw0Ny4yODIwNzU4IDMxLjUxNDE3OCw0OC4xMjgwNTEgMzAuMDE0MTUwOCw0OC4xMjgwNTEgTDI4Ljc4ODUxODksNDguMTI4MDUxIFogTTM3LjUzNzE1MjgsNTMuNjYzNjcxNCBMNDYuNTE5MDIyNSw1My42NjM2NzE0IEw0Ni41MTkwMjI1LDUwLjg0OTg4NDMgTDQwLjg2NjQ4MTMsNTAuODQ5ODg0MyBMNDAuODY2NDgxMyw0OS41NDQxMzk5IEw0NS4zNjY1NjI3LDQ5LjU0NDEzOTkgTDQ1LjM2NjU2MjcsNDYuODc3NDc4OSBMNDAuODY2NDgxMyw0Ni44Nzc0Nzg5IEw0MC44NjY0ODEzLDQzLjk3MTczOCBMNDYuMjYyOTIwMyw0My45NzE3MzggTDQ2LjI2MjkyMDMsNDEuMTU3OTUwOSBMMzcuNTM3MTUyOCw0MS4xNTc5NTA5IEwzNy41MzcxNTI4LDUzLjY2MzY3MTQgWiIgaWQ9ImdseXBoIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=" alt="Point-Free"></a></div><div class="hide-m col-m col-d-3"><a href="/"><img src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMTQyIDE2IiB3aWR0aD0iMTQyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Im00My4zMDg0Nzg3LjA1ODc2Mzk0LjA3MDA2MDguMDUxNDI1MjggOS43NjA0OTc5IDcuODk0MzMwMDV2LTcuNjQ3NjMyMjRoMy45MDg3NzA4djE1LjQ3NDY4MTA3YzAgLjE2MTQ3NDktLjA1NTU0NTcuMjMyMTIwMi0uMjQ5OTU1Ni4wOTc0OTA1bC0uMDcwMDYwNy0uMDUyNjM2NC05Ljc2MDQ5NzktNy44NzE5MDI5M3Y3LjYwMjc3ODEzaC0zLjkwODc3MDl2LTE1LjQ1MjI1NDAzYzAtLjEyMTEwNjIuMDU1NTQ1Ny0uMjI0MDQ2NDcuMjQ5OTU1Ni0uMDk2Mjc5NDN6bTU0LjEyNDM0OTguNTEyNjY0NjN2My40MzEzNDIzMmgtNi40MDAzMjY1djMuNTQzNDc3N2g1LjY0NjAwMjN2My40MzEzNDIzMWgtNS42NDYwMDIzdjQuODQ0MjQ4aC00LjE2MDIxMjN2LTE1LjI1MDQxMDMzem05LjE3OTI0MzUgMGM0LjE4MzA3MSAwIDYuNTM3NDc3IDIuNjAxNTQwNTkgNi41Mzc0NzcgNS45ODgwMjg3NiAwIDIuMTk3ODUzMjUtLjk4MjkwOCAzLjk0NzE2NTA3LTIuODExNTcyIDQuOTMzOTU2MjdsMi43NjU4NTUgNC4zMjg0MjUzaC00LjUwMzA4N2wtMi4xNzE1MzktMy40OTg2MjM2aC0xLjU1NDM2NXYzLjQ5ODYyMzZoLTQuMTYwMjEydi0xNS4yNTA0MTAzM3ptMjAuNjA4Mzk5IDB2My40MzEzNDIzMmgtNi43NDMyMDJ2My41NDM0Nzc3aDUuNjIzMTQ0djMuMjUxOTI1NzFoLTUuNjIzMTQ0djEuNTkyMzIyM2g3LjA2MzIxOHYzLjQzMTM0MjNoLTExLjIyMzQzdi0xNS4yNTA0MTAzM3ptMTQuNDU5NTEzIDB2My40MzEzNDIzMmgtNi43NDMyMDF2My41NDM0Nzc3aDUuNjIzMTQ0djMuMjUxOTI1NzFoLTUuNjIzMTQ0djEuNTkyMzIyM2g3LjA2MzIxN3YzLjQzMTM0MjNoLTExLjIyMzQzdi0xNS4yNTA0MTAzM3ptLTExOC4zOTcxNjM2LS4zOTM5NTgxM2M0LjQ4MDIyODYgMCA4LjM0MzI4MjggMy4yMDcwNzE1OCA4LjM0MzI4MjggNy44MDQ2MjE3NiAwIDQuNTk3NTUwMi0zLjg2MzA1NDIgNy44MjcwNDg4LTguMzQzMjgyOCA3LjgyNzA0ODgtNC40ODAyMjg1IDAtOC4zNDMyODI4LTMuMjI5NDk4Ni04LjM0MzI4MjgtNy44MjcwNDg4IDAtNC41OTc1NTAxOCAzLjg2MzA1NDMtNy44MDQ2MjE3NiA4LjM0MzI4MjgtNy44MDQ2MjE3NnptLTE3LjM4NTM3NjY5LjE3OTQxNjU5YzQuMTgzMDcwNTkgMCA2LjUzNzQ3NjM5IDIuNjAxNTQwNTkgNi41Mzc0NzYzOSA1Ljk4ODAyODc2IDAgMy4zODY0ODgxOC0yLjM1NDQwNTggNS45NjU2MDE3MS02LjUzNzQ3NjM5IDUuOTY1NjAxNzFoLTEuNzM3MjMxNDh2My4yOTY3Nzk5aC00LjE2MDIxMjIzdi0xNS4yNTA0MTAzN3ptMzMuMTQ3ODEzNDkgMHYxNS4yNTA0MTAzN2gtNC4xNjAyMTIzdi0xNS4yNTA0MTAzN3ptMzMuNDkwNjg4MSAwdjMuNDMxMzQyMzNoLTQuMTE0NDk1NnYxMS44MTkwNjgwNGgtNC4xNjAyMTIzdi0xMS44MTkwNjgwNGgtNC4xMTQ0OTU2di0zLjQzMTM0MjMzem01LjY5NTY1OTUgNS41NDI0OTQ2NSAzLjI1NDQ2MjcgMy4yNTQ0NjI3OS0zLjIzMjQ4ODEgMy4yMzI0ODgxMy0zLjI1NDQ2MjgtMy4yNTQ0NjI3OHptLTU0Ljk0ODc4NDQtMi4xNzg0MzM1NWMtMi42MDU4NDcyIDAtNC4wOTE2MzczIDEuODYxNDQ3MTUtNC4wOTE2MzczIDQuMjYxMTQ0MDcgMCAyLjM5OTY5NjkgMS40ODU3OTAxIDQuMjgzNTcxMSA0LjA5MTYzNzMgNC4yODM1NzExczQuMDkxNjM3My0xLjg4Mzg3NDIgNC4wOTE2MzczLTQuMjgzNTcxMWMwLTIuMzk5Njk2OTItMS40ODU3OTAxLTQuMjYxMTQ0MDctNC4wOTE2MzczLTQuMjYxMTQ0MDd6bTgzLjEyMzUyNjYuMzA0MjQ5ODRoLTEuNTMxNTA2djUuMDQ2MDkxNjVoMS41MzE1MDZjMS44NzQzODIgMCAyLjU2MDEzMS0xLjAzMTY0NTQgMi41NjAxMzEtMi41MTE4MzIyOSAwLTEuNDgwMTg2ODgtLjY4NTc0OS0yLjUzNDI1OTM2LTIuNTYwMTMxLTIuNTM0MjU5MzZ6bS0xMDAuNzE0NjI4MDctLjIxNDU0MTU0aC0xLjUzMTUwNjd2NS4wNDYwOTE2NWgxLjUzMTUwNjdjMS44NzQzODEzNCAwIDIuNTYwMTMwNi0xLjAzMTY0NTQgMi41NjAxMzA2LTIuNTExODMyMjkgMC0xLjQ4MDE4Njg4LS42ODU3NDkyNi0yLjUzNDI1OTM2LTIuNTYwMTMwNi0yLjUzNDI1OTM2eiIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9zdmc+" alt="Point-Free"></a></div><div class=" col-m col-d-9"><ul class="list-reset end-m fg-black normal h6 lh-4"><li class="m-pl2 inline"><a href="/pricing" class="pf-link-gray650">Pricing</a></li><li class="m-pl2 inline"><a class="pf-link-gray650" href="/collections">Collections</a></li><li class="m-pl2 inline"><a href="/blog" class="pf-link-gray650">Blog</a></li><li class="m-pl2 inline"><a href="/gifts" class="pf-link-gray650">Gifts</a></li><li class="m-pl2 inline"><a href="/account" class="pf-link-gray650">Account</a></li></ul></div></div></div></div><form action="/subscribe" id="subscribe-form" method="post" onsubmit="event.preventDefault()" style="max-width:900px;margin-right:auto;margin-left:auto"><input name="pricing[lane]" type="hidden" value="team"><div class="d-ml4 d-mr4 m-ml2 m-mr2 m-pt3 m-pb3 border-bottom border-gray-850 row"><div class=" col-m col-m-12"><h1 class="fg-black bold ts-d-r3 ts-m-r2 lh-2">Subscribe</h1></div><div class="start-m col-m">You selected the <strong>Team</strong> plan</div><div class="end-m col-m"><a class="pf-link-gray650 underline-link" href="http://localhost:8080/pricing">Change plan</a></div><div class=" col-m col-m-12"><ul class="m-pl0 m-pr0 m-pt0 m-pb0 m-ml3 fg-gray400 fg-black normal h5 lh-4 ts-d-r0_875 ts-m-r1 fg-gray400" style="flex-grow:1;flex-shrink:0;flex-basis:auto"><li class="m-pt1"><div class="pricing-plan-feature"><p>All 2 episodes with transcripts</p>
+</div></li><li class="m-pt1"><div class="pricing-plan-feature"><p>Over 0 hours of video</p>
+</div></li><li class="m-pt1"><div class="pricing-plan-feature"><p>Private RSS feed for offline viewing in podcast apps</p>
+</div></li><li class="m-pt1"><div class="pricing-plan-feature"><p>Download all episode playgrounds</p>
+</div></li><li class="m-pt1"><div class="pricing-plan-feature"><p><a href="/subscribe/personal?useRegionalDiscount=true">Regional</a>
+and <a href="/blog/posts/10-announcing-student-discounts">education</a> discounts
+available</p>
+</div></li></ul></div></div><div class="d-ml4 d-mr4 m-ml2 m-mr2 m-pt3 m-pb3 border-bottom border-gray-850 row"><div class="d-pb2 m-pb1 col-m col-m-12"><h1 class="fg-black bold ts-d-r2 ts-m-r1_5 lh-2 m-mt0">Team members</h1></div><div id="team-owner" class="border border-gray-850 m-pl2 m-pr2 m-pt2 m-pb2 m-mt1 col-m col-m-12" style="line-height:0"><div class="flex middle-m"><input name="isOwnerTakingSeat" type="hidden" value="true"><img src="https://avatars0.githubusercontent.com/u/1?v=4" alt class="bg-green circle m-mr1" style="width:24px;height:24px"><span class="w-100p">Blob</span><a id="remove-yourself-button" class="cursor-pointer fg-red pf-link-red light fg-black normal h6 lh-4 underline-link" onclick="var ownerRow = this.parentNode.parentNode
+ownerRow.parentNode.removeChild(ownerRow)
+
+var teamMember = document.getElementById(&quot;team-member-template-without-remove&quot;).content.cloneNode(true)
+var teamMembersContainer = document.getElementById(&quot;team-members&quot;)
+teamMembersContainer.insertBefore(teamMember, teamMembersContainer.firstChild)
+
+updateSeats()">Remove&nbsp;yourself</a></div></div><div id="team-members" class=" col-m col-m-12"><div class="border border-gray-850 m-pl2 m-pr2 m-pt2 m-pb2 m-mt1 col-m col-m-12" style="line-height:0"><div class="flex middle-m"><img src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMjAgMTYiIHdpZHRoPSIyMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC00KSI+PHBhdGggZD0ibTAgMGgyNHYyNGgtMjR6Ii8+PHBhdGggZD0ibTIwIDRoLTE2Yy0xLjEgMC0xLjk5LjktMS45OSAybC0uMDEgMTJjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMnYtMTJjMC0xLjEtLjktMi0yLTJ6bTAgMTRoLTE2di0xMGw4IDUgOC01em0tOC03LTgtNWgxNnoiIGZpbGw9IiMxMjEyMTIiIGZpbGwtcnVsZT0ibm9uemVybyIvPjwvZz48L3N2Zz4=" alt class="m-mr1" style="width:24px;height:24px"><input type="email" placeholder="blob@pointfree.co" class="w-100p" name="teammate" style="border-top-width:0;border-right-width:0;border-bottom-width:0;border-left-width:0;outline:none" value></div></div></div><div class="m-pt3 col-m col-m-12"><div><template id="team-member-template"><div class="border border-gray-850 m-pl2 m-pr2 m-pt2 m-pb2 m-mt1 col-m col-m-12" style="line-height:0"><div class="flex middle-m"><img src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMjAgMTYiIHdpZHRoPSIyMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC00KSI+PHBhdGggZD0ibTAgMGgyNHYyNGgtMjR6Ii8+PHBhdGggZD0ibTIwIDRoLTE2Yy0xLjEgMC0xLjk5LjktMS45OSAybC0uMDEgMTJjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMnYtMTJjMC0xLjEtLjktMi0yLTJ6bTAgMTRoLTE2di0xMGw4IDUgOC01em0tOC03LTgtNWgxNnoiIGZpbGw9IiMxMjEyMTIiIGZpbGwtcnVsZT0ibm9uemVybyIvPjwvZz48L3N2Zz4=" alt class="m-mr1" style="width:24px;height:24px"><input type="email" placeholder="blob@pointfree.co" class="w-100p" name="teammate" style="border-top-width:0;border-right-width:0;border-bottom-width:0;border-left-width:0;outline:none" value><a class="cursor-pointer fg-red pf-link-red light fg-black normal h6 lh-4 underline-link" onclick="var teamMemberRow = this.parentNode.parentNode
+teamMemberRow.parentNode.removeChild(teamMemberRow)
+updateSeats()">Remove</a></div></div></template><template id="team-member-template-without-remove"><div class="border border-gray-850 m-pl2 m-pr2 m-pt2 m-pb2 m-mt1 col-m col-m-12" style="line-height:0"><div class="flex middle-m"><img src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMjAgMTYiIHdpZHRoPSIyMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC00KSI+PHBhdGggZD0ibTAgMGgyNHYyNGgtMjR6Ii8+PHBhdGggZD0ibTIwIDRoLTE2Yy0xLjEgMC0xLjk5LjktMS45OSAybC0uMDEgMTJjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMnYtMTJjMC0xLjEtLjktMi0yLTJ6bTAgMTRoLTE2di0xMGw4IDUgOC01em0tOC03LTgtNWgxNnoiIGZpbGw9IiMxMjEyMTIiIGZpbGwtcnVsZT0ibm9uemVybyIvPjwvZz48L3N2Zz4=" alt class="m-mr1" style="width:24px;height:24px"><input type="email" placeholder="blob@pointfree.co" class="w-100p" name="teammate" style="border-top-width:0;border-right-width:0;border-bottom-width:0;border-left-width:0;outline:none" value></div></div></template><a id="add-team-member-button" class="medium cursor-pointer nowrap pf-link-black fg-black bg-white h5 m-pl2 m-pr2 m-pt2 m-pb2 border border-gray-850" onclick="var teamMember = document.getElementById(&quot;team-member-template&quot;).content.cloneNode(true)
+document.getElementById(&quot;team-members&quot;).appendChild(teamMember)
+updateSeats()">Add team member</a></div></div><p class="fg-black normal h6 lh-4 fg-gray400 m-pt3">You must have at least two seats for your team subscription. You can add additional team members at any time
+from your account page.</p></div><div class="d-ml4 d-mr4 m-ml2 m-mr2 m-pt3 m-pb3 border-bottom border-gray-850 row"><div class="d-pb2 m-pb1 col-m col-m-12"><h1 class="fg-black bold ts-d-r2 ts-m-r1_5 lh-2 m-mt0">Billing interval</h1></div><div class="border border-gray-850 m-pl2 m-pr2 m-pt2 m-pb2 col-m col-m-12" style="line-height:0"><label class="cursor-pointer flex items-baseline"><div><input checked id="yearly" type="radio" name="pricing[billing]" value="yearly"></div><div class="m-ml2"><h5 class="fg-black bold ts-d-r1 ts-m-r0_875 lh-1 m-ml0 m-mr0 m-mt0 m-mb0">Yearly — Save 25% off monthly billing!</h5><p class="m-pt1 fg-black normal h6 lh-4 fg-gray650">$144 per member per year</p></div></label></div><div class="border-left border-right border-bottom border-gray-850 m-pl2 m-pr2 m-pt2 m-pb2 col-m col-m-12" style="line-height:0"><label class="cursor-pointer flex items-baseline"><div><input id="monthly" type="radio" name="pricing[billing]" value="monthly"></div><div class="m-ml2"><h5 class="fg-black bold ts-d-r1 ts-m-r0_875 lh-1 m-ml0 m-mr0 m-mt0 m-mb0">Monthly</h5><p class="m-pt1 fg-black normal h6 lh-4 fg-gray650">$16 per member, per month</p></div></label></div></div><div class="d-ml4 d-mr4 m-ml2 m-mr2 m-pt3 m-pb3 border-bottom border-gray-850 row"><div class="d-pb2 m-pb1 col-m col-m-12"><h1 class="fg-black bold ts-d-r2 ts-m-r1_5 lh-2 m-mt0">Payment info</h1></div><label for="card" class="nowrap fg-black bg-white fg-black bold ts-d-r1 ts-m-r0_875 lh-1">Credit or debit card</label><div class="border border-gray-850 m-pl2 m-pr2 m-pt2 m-pb2 m-mt1 col-m col-m-12" style="line-height:0"><div class="flex middle-m"><div class="w-100p" data-stripe-key="pk_test" id="card-element"></div></div></div><div class=" col-m col-m-12"><div class="fg-red fg-black normal h6 lh-4" id="card-errors"></div><input name="paymentMethodID" type="hidden"><script src></script><script>window.addEventListener("load", function() {
+  var form = document.getElementById("subscribe-form")
+  var displayError = document.getElementById("card-errors")
+
+  var apiKey = document.getElementById("card-element").dataset.stripeKey
+  var stripe = Stripe(apiKey, { apiVersion: "2020-08-27" })
+  var elements = stripe.elements()
+  var style = {
+    base: {
+      fontSize: "16px",
+    }
+  }
+
+  window.paymentRequest = stripe.paymentRequest({
+    country: 'US',
+    currency: 'usd',
+    total: { label: '', amount: 100, }
+  });
+  const paymentRequestButton = elements.create('paymentRequestButton', {
+    paymentRequest: window.paymentRequest,
+  });
+
+  var card = elements.create("card", { style: style })
+  card.mount("#card-element")
+  card.addEventListener("change", function(event) {
+    if (event.error) {
+      displayError.textContent = event.error.message
+    } else {
+      displayError.textContent = ""
+    }
+  });
+
+  window.paymentRequest.on('paymentmethod', async (ev) => {
+    setFormEnabled(false, function() { return true })
+    ev.complete('success')
+    form.paymentMethodID.value = ev.paymentMethod.id
+    setFormEnabled(true, function(el) { return el.tagName != "BUTTON" })
+    form.submit()
+  });
+
+  function setFormEnabled(isEnabled, elementsMatching) {
+    for (var idx = 0; idx < form.length; idx++) {
+      var formElement = form[idx]
+      if (elementsMatching(formElement)) {
+        formElement.disabled = !isEnabled
+        if (formElement.tagName == "BUTTON") {
+          formElement.textContent = isEnabled ? "Subscribe" : "Subscribing…"
+        }
+      }
+    }
+  }
+
+  var submitting = false
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault()
+    if (submitting) { return }
+
+    displayError.textContent = ""
+    submitting = true
+    setFormEnabled(false, function() { return true })
+
+    try {
+      const result = await stripe.createPaymentMethod({
+        type: 'card',
+        card: card,
+      })
+      if (result.error) {
+        displayError.textContent = result.error.message
+      } else {
+        form.paymentMethodID.value = result.paymentMethod.id
+        setFormEnabled(true, function(el) { return el.tagName != "BUTTON" })
+        form.submit()
+        return // NB: Early out so to not re-enable form.
+      }
+    } catch {
+      displayError.innerHTML = "An error occurred. Please try again or contact <a href='mailto:support@pointfree.co'>support@pointfree.co</a>."
+    }
+
+    submitting = false
+    setFormEnabled(true, function(el) { return true })
+  });
+
+  (async () => {
+    const result = await window.paymentRequest.canMakePayment();
+    if (result) {
+      paymentRequestButton.mount('#payment-request-button');
+      document.getElementById("apple-pay-container").style.display = 'block'
+      updateSeats()
+    } else {
+      document.getElementById('payment-request-button').style.display = 'none';
+    }
+  })();
+})</script></div><div id="apple-pay-container" class="m-ml0 m-pt3 none col-m col-m-12" style="line-height:0"><label for="apple-pay" class="nowrap fg-black bg-white fg-black bold ts-d-r1 ts-m-r0_875 lh-1">or Apple Pay</label><div id="payment-request-button" class="col-m-12 col-d-4 m-mt2"></div></div></div><div class="d-ml4 d-mr4 m-ml2 m-mr2 d-pb4 d-pt3 m-pb4 m-pt3 middle-m row"><div class="m-pb4 col-m col-m-12"><span class="fg-black normal h6 lh-4 fg-gray400" id="pricing-preview"></span></div><div class="start-m col-m"><div class="flex align-center middle-m"><h3 class="fg-black bold ts-d-r3 ts-m-r2 lh-2 normal m-mt0 m-mb0" id="total"></h3><input name="pricing[quantity]" type="hidden"><script>function format(money) {
+  return "$" + money.toFixed(2).replace(/\.00$/, "")
+}
+function updateSeats() {
+  var teamMembers = document.getElementById("team-members")
+  var teamMemberInputs = teamMembers == null ? [] : Array.from(teamMembers.getElementsByTagName("INPUT"))
+  for (var idx = 0; idx < teamMemberInputs.length; idx++) {
+    teamMemberInputs[idx].name = "teammate"
+  }
+  var teamOwnerIsTakingSeat = document.getElementById("team-owner") != null
+  var seats = teamMembers
+    ? teamMembers.childNodes.length + (teamOwnerIsTakingSeat ? 1 : 0)
+    : 1
+  var form = document.getElementById("subscribe-form")
+  form["pricing[quantity]"].value = seats
+  var regionalDiscount = 1.0
+  var monthly = form["pricing[billing]"].value == "monthly"
+  var monthlyPricePerSeat = (
+    monthly
+      ? 1600 * 0.01 * regionalDiscount
+      : 1200 * 0.01 * regionalDiscount
+  )
+  const monthlyPrice = seats * monthlyPricePerSeat
+  const total = monthly
+    ? monthlyPrice
+    : (monthlyPrice * 12 - 0 * regionalDiscount)
+  document.getElementById("total").textContent = format(total)
+  document.getElementById("pricing-preview").innerHTML = (
+    "You will be charged <strong>"
+      + format(monthlyPricePerSeat)
+      + " per month</strong>"
+      + (seats > 1 ? " times <strong>" + seats + " seats</strong>" : "")
+      + (monthly ? "" : " times <strong>12 months</strong>")
+      + "."
+  )
+  if (window.paymentRequest) {
+    window.paymentRequest.update({
+      total: {
+        label: monthly ? "Monthly subscription" : "Yearly subscription",
+        amount: total * 100
+      }
+    })
+  }
+}
+window.addEventListener("load", function() {
+  updateSeats()
+  var form = document.getElementById("subscribe-form")
+  form.addEventListener("change", updateSeats)
+})</script><span class="fg-black normal h6 lh-4 fg-gray400 m-ml1 m-pb1">Total</span></div></div><div class="end-m col-m"><button class="border-none text-decoration-none cursor-pointer bold ts-d-r1 ts-m-r1 m-pl2 m-pr2 m-pt2 m-pb2 center bg-black fg-white pf-link-white">Subscribe</button></div></div></form><footer class="row d-pl4 d-pr4 d-pt4 d-pb4 m-pl3 m-pr3 m-pt3 m-pb3 bg-black"><div class=" col-m col-d-6 col-m-12"><div class="d-pr4 m-pb2"><h4 class="fg-black bold ts-d-r1_5 ts-m-r1_25 lh-2 m-mb0"><a href="/" class="pf-link-white">Point-Free</a></h4><p class="fg-black normal h5 lh-4 fg-white">A video series on functional programming and the Swift programming language. Hosted by <a href="https://www.twitter.com/mbrandonw" class="text-decoration-none pf-link-green">Brandon&nbsp;Williams</a> and <a href="https://www.twitter.com/stephencelis" class="text-decoration-none pf-link-green">Stephen&nbsp;Celis</a>.</p></div></div><div class=" col-m col-d-2 col-m-4"><div><h5 class="fg-black bold ts-d-r0_875 ts-m-r0_75 lh-1 caps fg-white">Content</h5><ol class="list-reset"><li><a class="pf-link-purple fg-black normal h5 lh-4" href="/pricing">Pricing</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="/gifts">Gifts</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="/">Videos</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="/collections">Collections</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="/blog">Blog</a></li></ol></div></div><div class=" col-m col-d-2 col-m-4"><div><h5 class="fg-black bold ts-d-r0_875 ts-m-r0_75 lh-1 caps fg-white">More</h5><ol class="list-reset"><li><a class="pf-link-purple fg-black normal h5 lh-4" href="/about">About Us</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="https://hachyderm.io/@pointfreeco" rel="me">Mastodon</a></li><li class="none"><a class="pf-link-purple fg-black normal h5 lh-4" href="https://hachyderm.io/@mbrandonw" rel="me">@mbrandonw</a></li><li class="none"><a class="pf-link-purple fg-black normal h5 lh-4" href="https://hachyderm.io/@stephencelis" rel="me">@stephencelis</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="https://www.twitter.com/pointfreeco">Twitter</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="https://github.com/pointfreeco">GitHub</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="mailto:support@pointfree.co">Contact us</a></li><li><a class="pf-link-purple fg-black normal h5 lh-4" href="/privacy">Privacy Policy</a></li></ol></div></div><div class=" col-m col-d-6 col-m-12"><p class="fg-gray400 fg-black normal h6 lh-4 m-pt2">© 2018 Point-Free, Inc. All rights are reserved for the videos and transcripts on this site. All other content is licensed under <a class="pf-link-gray650" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>, and the underlying <a class="pf-link-gray650" href="https://github.com/pointfreeco/pointfreeco">source code</a> to run this site is licensed under the <a class="pf-link-gray650" href="https://github.com/pointfreeco/pointfreeco/blob/main/LICENSE">MIT license</a></p></div></footer></body></html>


### PR DESCRIPTION
This makes `siteMiddleware` fully async instead of returning an `IO`. This is a big change because all tests need to be updated to await directly instead of going through `IO`, but it opens us up to writing fully async site endpoints with no mention of IO.