### PR TITLE
Move Slack invite URL to env var

### DIFF
--- a/.pf-env.example
+++ b/.pf-env.example
@@ -8,6 +8,7 @@
   "GITHUB_CLIENT_SECRET": "deadbeef-client-secret",
   "MAILGUN_DOMAIN": "mg.domain.com",
   "MAILGUN_PRIVATE_API_KEY": "deadbeef-mg-api-key",
+  "PF_COMMUNITY_SLACK_INVITE_URL": "https://join.slack.com/t/pointfreecommunity/shared_invite/zt-1o8l02r36-lygnfRjdoCZA3GtpG9bo_Q",
   "REGIONAL_DISCOUNT_COUPON_ID": "regional-discount",
   "RSS_USER_AGENT_WATCHLIST": "",
   "STRIPE_ENDPOINT_SECRET": "whsec_test",

--- a/Sources/Models/BlogPosts/BlogPost0100_Anniversary.swift
+++ b/Sources/Models/BlogPosts/BlogPost0100_Anniversary.swift
@@ -68,10 +68,7 @@ public let post0100_Anniversary = BlogPost(
     ),
     .init(
       content: "Join the Point-Free Community Slack",
-      type: .button(
-        href:
-          "https://join.slack.com/t/pointfreecommunity/shared_invite/zt-1o8l02r36-lygnfRjdoCZA3GtpG9bo_Q"
-      )
+      type: .button(href: "/slack-invite")
     ),
     .init(
       content: ###"""

--- a/Sources/PointFree/EnvVars.swift
+++ b/Sources/PointFree/EnvVars.swift
@@ -29,6 +29,7 @@ public struct EnvVars: Codable {
   public var postgres: Postgres
   public var regionalDiscountCouponId: Coupon.ID
   public var rssUserAgentWatchlist: [String]
+  public var slackInviteURL: String
   public var stripe: Stripe
   public var vimeoBearer: String
 
@@ -44,6 +45,7 @@ public struct EnvVars: Codable {
     postgres: Postgres = Postgres(),
     regionalDiscountCouponId: Coupon.ID = "regional-discount",
     rssUserAgentWatchlist: [String] = [],
+    slackInviteURL: String = "http://slack.com",
     stripe: Stripe = Stripe(),
     vimeoBearer: String = ""
   ) {
@@ -58,6 +60,7 @@ public struct EnvVars: Codable {
     self.postgres = postgres
     self.regionalDiscountCouponId = regionalDiscountCouponId
     self.rssUserAgentWatchlist = rssUserAgentWatchlist
+    self.slackInviteURL = slackInviteURL
     self.stripe = stripe
     self.vimeoBearer = vimeoBearer
   }
@@ -70,6 +73,7 @@ public struct EnvVars: Codable {
     case port = "PORT"
     case rssUserAgentWatchlist = "RSS_USER_AGENT_WATCHLIST"
     case regionalDiscountCouponId = "REGIONAL_DISCOUNT_COUPON_ID"
+    case slackInviteURL = "PF_COMMUNITY_SLACK_INVITE_URL"
     case vimeoBearer = "VIMEO_BEARER"
   }
 
@@ -191,6 +195,7 @@ extension EnvVars {
     self.rssUserAgentWatchlist = (try container.decode(String.self, forKey: .rssUserAgentWatchlist))
       .split(separator: ",")
       .map(String.init)
+    self.slackInviteURL = try container.decode(String.self, forKey: .slackInviteURL)
     self.stripe = try .init(from: decoder)
     self.vimeoBearer = try container.decode(String.self, forKey: .vimeoBearer)
   }
@@ -211,6 +216,7 @@ extension EnvVars {
       String(self.rssUserAgentWatchlist.joined(separator: ",")), forKey: .rssUserAgentWatchlist
     )
     try container.encode(self.regionalDiscountCouponId, forKey: .regionalDiscountCouponId)
+    try container.encode(self.slackInviteURL, forKey: .slackInviteURL)
     try self.stripe.encode(to: encoder)
     try container.encode(self.vimeoBearer, forKey: .vimeoBearer)
   }

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -278,6 +278,10 @@ private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) async -> Conn<Resp
   case .resume:
     return await resumeMiddleware(conn.map(const(())))
 
+  case .slackInvite:
+    @Dependency(\.envVars) var envVars
+    return await (conn |> redirect(to: envVars.slackInviteURL)).performAsync()
+
   case let .subscribe(data):
     return await subscribeMiddleware(conn.map(const(currentUser .*. data .*. unit)))
       .performAsync()

--- a/Sources/PointFreeRouter/Routes.swift
+++ b/Sources/PointFreeRouter/Routes.swift
@@ -37,6 +37,7 @@ public enum SiteRoute: Equatable {
   case pricingLanding
   case privacy
   case resume
+  case slackInvite
   case subscribe(SubscribeData? = nil)
   case subscribeConfirmation(
     lane: Pricing.Lane,
@@ -393,6 +394,10 @@ let router = OneOf {
 
   Route(.case(SiteRoute.resume)) {
     Path { "resume" }
+  }
+
+  Route(.case(SiteRoute.slackInvite)) {
+    Path { "slack-invite" }
   }
 
   Route(.case(SiteRoute.clips)) {

--- a/Tests/PointFreeTests/EnvVarTests.swift
+++ b/Tests/PointFreeTests/EnvVarTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class EnvVarTests: TestCase {
   override func setUp() async throws {
     try await super.setUp()
-    //    SnapshotTesting.isRecording=true
+    //SnapshotTesting.isRecording=true
   }
 
   func testDecoding() async throws {
@@ -26,6 +26,7 @@ class EnvVarTests: TestCase {
       "PORT": "8080",
       "REGIONAL_DISCOUNT_COUPON_ID": "regional-discount",
       "RSS_USER_AGENT_WATCHLIST": "blob,gob",
+      "PF_COMMUNITY_SLACK_INVITE_URL": "http://slack.com",
       "STRIPE_ENDPOINT_SECRET": "whsec_test",
       "STRIPE_PUBLISHABLE_KEY": "pk_test",
       "STRIPE_SECRET_KEY": "sk_test",

--- a/Tests/PointFreeTests/__Snapshots__/EnvVarTests/testDecoding.1.txt
+++ b/Tests/PointFreeTests/__Snapshots__/EnvVarTests/testDecoding.1.txt
@@ -44,30 +44,34 @@
     value: "deadbeef-mg-api-key"
   ),
   [11]: (
+    key: "PF_COMMUNITY_SLACK_INVITE_URL",
+    value: "http://slack.com"
+  ),
+  [12]: (
     key: "PORT",
     value: "8080"
   ),
-  [12]: (
+  [13]: (
     key: "REGIONAL_DISCOUNT_COUPON_ID",
     value: "regional-discount"
   ),
-  [13]: (
+  [14]: (
     key: "RSS_USER_AGENT_WATCHLIST",
     value: "blob,gob"
   ),
-  [14]: (
+  [15]: (
     key: "STRIPE_ENDPOINT_SECRET",
     value: "whsec_test"
   ),
-  [15]: (
+  [16]: (
     key: "STRIPE_PUBLISHABLE_KEY",
     value: "pk_test"
   ),
-  [16]: (
+  [17]: (
     key: "STRIPE_SECRET_KEY",
     value: "sk_test"
   ),
-  [17]: (
+  [18]: (
     key: "VIMEO_BEARER",
     value: "deadbeef"
   )


### PR DESCRIPTION
Seems like it may expire sometimes, so easier to maintain the link if we move it to env vars.