### PR TITLE
Fix progress when watching from collection.

### DIFF
--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -158,6 +158,12 @@ private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) async -> Conn<Resp
     return await episodeResponse(conn.map(const(episodeParam .*. collectionSlug .*. unit)))
       .performAsync()
 
+  case let .collections(
+    .collection(_, .section(_, .progress(param: param, percent: percent)))
+  ):
+    return await progressResponse(conn.map(const(param .*. percent .*. unit)))
+      .performAsync()
+
   case let .discounts(couponId, billing):
     let subscribeData = SubscribeConfirmationData(
       billing: billing ?? .yearly,

--- a/Sources/PointFreeRouter/Routes.swift
+++ b/Sources/PointFreeRouter/Routes.swift
@@ -70,8 +70,9 @@ public enum SiteRoute: Equatable {
     }
 
     public enum Section: Equatable {
-      case show
       case episode(Either<String, Episode.ID>)
+      case progress(param: Either<String, Episode.ID>, percent: Int)
+      case show
     }
   }
 
@@ -179,6 +180,14 @@ struct CollectionsRouter: ParserPrinter {
 
               Route(.case(SiteRoute.Collections.Section.episode)) {
                 Path { SlugOrID<Episode.ID>() }
+              }
+              Route(.case(SiteRoute.Collections.Section.progress(param:percent:))) {
+                Method.post
+                Path {
+                  SlugOrID<Episode.ID>()
+                  "progress"
+                }
+                Query { Field("percent") { Digits() } }
               }
             }
           }

--- a/Tests/PointFreeRouterTests/PointFreeRouterTests.swift
+++ b/Tests/PointFreeRouterTests/PointFreeRouterTests.swift
@@ -186,4 +186,17 @@ class PointFreeRouterTests: TestCase {
     XCTAssertEqual(try siteRouter.match(request: request), route)
     XCTAssertEqual(try siteRouter.request(for: route), request)
   }
+
+  func testCollectionEpisodeProgress() throws {
+    var request = URLRequest(
+      url: URL(string: "http://localhost:8080/collections/tca/basics/1/progress?percent=50")!
+    )
+    request.httpMethod = "POST"
+    let route = SiteRoute.collections(
+      .collection("tca", .section("basics", .progress(param: .left("1"), percent: 50)))
+    )
+
+    XCTAssertEqual(try siteRouter.match(request: request), route)
+    XCTAssertEqual(try siteRouter.request(for: route),  request)
+  }
 }


### PR DESCRIPTION
Easy fix for this bug. We could also make a root level `/progress` endpoint for reporting episode progress, but will save that for another time.