### PR TITLE
Better messaging for login errors

### DIFF
--- a/Sources/PointFree/Auth.swift
+++ b/Sources/PointFree/Auth.swift
@@ -1,3 +1,4 @@
+import CustomDump
 import Dependencies
 import Either
 import Foundation
@@ -7,6 +8,7 @@ import Models
 import PointFreeDependencies
 import PointFreePrelude
 import PointFreeRouter
+import PostgresNIO
 import Prelude
 import Tuple
 import UrlFormEncoding
@@ -18,7 +20,7 @@ import UrlFormEncoding
 let gitHubCallbackResponse =
   requireLoggedOutUser
   <<< requireAuthCodeAndAccessToken
-  <| gitHubAuthTokenMiddleware
+  <| { conn in IO { await gitHubAuthTokenMiddleware(conn) } }
 
 private let requireAuthCodeAndAccessToken:
   MT<Tuple2<String?, String?>, Tuple2<GitHub.AccessToken, String?>> =
@@ -82,94 +84,89 @@ public func fetchUser<A>(_ conn: Conn<StatusLineOpen, T2<Models.User.ID, A>>)
     .map { conn.map(const($0 .*. conn.data.second)) }
 }
 
-private func fetchOrRegisterUser(env: GitHubUserEnvelope) -> EitherIO<Error, Models.User> {
+private func fetchOrRegisterUser(env: GitHubUserEnvelope) async throws -> Models.User {
   @Dependency(\.database) var database
 
-  return EitherIO {
-    do {
-      return try await database.fetchUserByGitHub(env.gitHubUser.id)
-    } catch {
-      return try await registerUser(env: env).performAsync()
-    }
+  do {
+    return try await database.fetchUserByGitHub(env.gitHubUser.id)
+  } catch {
+    return try await registerUser(env: env)
   }
 }
 
-private func registerUser(env: GitHubUserEnvelope) -> EitherIO<Error, Models.User> {
+private struct AlreadyExists: Error {
+  let email: GitHubUser.Email
+}
+
+private func registerUser(env: GitHubUserEnvelope) async throws -> Models.User {
   @Dependency(\.database) var database
+  @Dependency(\.fireAndForget) var fireAndForget
   @Dependency(\.gitHub) var gitHub
   @Dependency(\.date.now) var now
 
-  return EitherIO { try await gitHub.fetchEmails(env.accessToken) }
-    .map { emails in emails.first(where: \.primary) }
-    .mapExcept(requireSome)  // todo: better error messaging
-    .flatMap { email in
-
-      EitherIO {
-        try await database.registerUser(
-          withGitHubEnvelope: env,
-          email: email.email,
-          now: { now }
-        )
-      }
-      .flatMap { user in
-        EitherIO(
-          run: IO { () -> Either<Error, Models.User> in
-
-            // Fire-and-forget notify user that they signed up
-            Task {
-              _ = try await sendEmail(
-                to: [email.email],
-                subject: "Point-Free Registration",
-                content: inj2(registrationEmailView(env.gitHubUser))
-              )
-            }
-
-            return .right(user)
-          })
-      }
+  let email = try await gitHub.fetchEmails(env.accessToken).first(where: \.primary).unwrap()
+  do {
+    let user = try await database.registerUser(
+      withGitHubEnvelope: env,
+      email: email.email,
+      now: { now }
+    )
+    await fireAndForget {
+      try await sendEmail(
+        to: [email.email],
+        subject: "Point-Free Registration",
+        content: inj2(registrationEmailView(env.gitHubUser))
+      )
     }
+    return user
+  } catch let PostgresError.server(error) where error.fields[.constraintName] == "users_email_key" {
+    throw AlreadyExists(email: email)
+  }
 }
 
-/// Exchanges a github code for an access token and loads the user's data.
+/// Exchanges a GitHub code for an access token and loads the user's data.
 private func gitHubAuthTokenMiddleware(
   _ conn: Conn<StatusLineOpen, Tuple2<GitHub.AccessToken, String?>>
-)
-  -> IO<Conn<ResponseEnded, Data>>
-{
+) async -> Conn<ResponseEnded, Data> {
+  @Dependency(\.fireAndForget) var fireAndForget
   @Dependency(\.gitHub) var gitHub
   @Dependency(\.siteRouter) var siteRouter
 
   let (token, redirect) = lower(conn.data)
 
-  return EitherIO { try await gitHub.fetchUser(token) }
-    .map { user in GitHubUserEnvelope(accessToken: token, gitHubUser: user) }
-    .flatMap(fetchOrRegisterUser(env:))
-    .flatMap { user in
-      refreshStripeSubscription(for: user)
-        .map(const(user))
+  do {
+    let gitHubUser = try await gitHub.fetchUser(token)
+    let env = GitHubUserEnvelope(accessToken: token, gitHubUser: gitHubUser)
+    let user = try await fetchOrRegisterUser(env: env)
+    try await refreshStripeSubscription(for: user)
+    return conn.redirect(to: redirect ?? siteRouter.path(for: .home)) {
+      $0.writeSessionCookie { $0.user = .standard(user.id) }
     }
-    .withExcept(notifyError(subject: "GitHub Auth Failed"))
-    .run
-    .flatMap(
-      either(
-        const(
-          conn
-            |> PointFree.redirect(
-              to: .home,
-              headersMiddleware: flash(
-                .error,
-                "We were not able to log you in with GitHub. Please try again."
-              )
-            )
-        )
-      ) { user in
-        conn
-          |> HttpPipeline.redirect(
-            to: redirect ?? siteRouter.path(for: .home),
-            headersMiddleware: writeSessionCookieMiddleware { $0.user = .standard(user.id) }
-          )
-      }
-    )
+  } catch let error as AlreadyExists {
+    return conn.redirect(to: .home) {
+      $0.flash(
+        .error, """
+        The primary email address associated with your GitHub account, \
+        \(error.email.email.rawValue), is already registered with Point-Free under a different \
+        [GitHub account](https://github.com/settings) account.
+
+        Log into the GitHub account associated with your Point-Free account before trying again, \
+        or contact <support@pointfree.co>.
+        """
+      )
+    }
+  } catch {
+    await fireAndForget {
+      try await sendEmail(
+        to: adminEmails,
+        subject: "GitHub Auth Failed",
+        content: inj1(String(customDumping: error))
+      )
+    }
+    return conn.redirect(to: .home) {
+      $0.flash(.error, "We were not able to log you in with GitHub. Please try again.")
+    }
+  }
 }
 
 private func requireAccessToken<A>(
@@ -206,20 +203,17 @@ private func requireAccessToken<A>(
   }
 }
 
-private func refreshStripeSubscription(for user: Models.User) -> EitherIO<Error, Prelude.Unit> {
+private func refreshStripeSubscription(for user: Models.User) async throws {
   @Dependency(\.database) var database
   @Dependency(\.stripe) var stripe
 
-  guard let subscriptionId = user.subscriptionId else { return pure(unit) }
+  guard let subscriptionId = user.subscriptionId else { return }
 
-  return EitherIO {
-    let subscription = try await database.fetchSubscriptionById(subscriptionId)
-    let stripeSubscription =
-      try await stripe
-      .fetchSubscription(subscription.stripeSubscriptionId)
-    _ = try await database.updateStripeSubscription(stripeSubscription)
-    return unit
-  }
+  let subscription = try await database.fetchSubscriptionById(subscriptionId)
+  let stripeSubscription =
+    try await stripe
+    .fetchSubscription(subscription.stripeSubscriptionId)
+  _ = try await database.updateStripeSubscription(stripeSubscription)
 }
 
 private func gitHubAuthorizationUrl(withRedirect redirect: String?) -> String {

--- a/Sources/PointFree/Emails/SendEmail.swift
+++ b/Sources/PointFree/Emails/SendEmail.swift
@@ -96,6 +96,7 @@ public func send(email: Email) async throws -> SendEmailResponse {
   return try await mailgun.sendEmail(email)
 }
 
+@discardableResult
 public func sendEmail(
   from: EmailAddress = supportEmail,
   to: [EmailAddress],

--- a/Sources/PointFree/SiteMiddleware.swift
+++ b/Sources/PointFree/SiteMiddleware.swift
@@ -292,7 +292,7 @@ private func render(conn: Conn<StatusLineOpen, Prelude.Unit>) async -> Conn<Resp
 
   case .slackInvite:
     @Dependency(\.envVars) var envVars
-    return await (conn |> redirect(to: envVars.slackInviteURL)).performAsync()
+    return await conn.redirect(to: envVars.slackInviteURL)
 
   case let .subscribe(data):
     return await subscribeMiddleware(conn.map(const(currentUser .*. data .*. unit)))

--- a/Tests/PointFreeTests/__Snapshots__/AuthTests/testAuth_WithRegisterUserFailure.1.Conn.txt
+++ b/Tests/PointFreeTests/__Snapshots__/AuthTests/testAuth_WithRegisterUserFailure.1.Conn.txt
@@ -1,0 +1,12 @@
+GET http://localhost:8080/github-auth?code=deadbeef
+Cookie: pf_session={}
+
+302 Found
+Location: /
+Referrer-Policy: strict-origin-when-cross-origin
+Set-Cookie: pf_session={"flash":{"message":"The primary email address associated with your GitHub account, blob@example.org, is already registered with Point-Free under a different [GitHub account](https:\/\/github.com\/settings) account.\n\nLog into the GitHub account associated with your Point-Free account before trying again, or contact <support@pointfree.co>.","priority":"error"}}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: SAMEORIGIN
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block


### PR DESCRIPTION
A common login error occurs for users with multiple GitHub accounts associated with the same primary email address, either because they've deleted and recreated their GitHub account, or from work accounts clashing with home accounts, etc. This PR checks for this issue and surfaces a better error message to users.