### PR TITLE
persist playback rate

### DIFF
--- a/Sources/Views/EpisodeVideoView.swift
+++ b/Sources/Views/EpisodeVideoView.swift
@@ -93,6 +93,10 @@ private func progressPollingScript(isEpisodeViewable: Bool) -> Node {
               httpRequest.send();
             }
           });
+          player.setPlaybackRate( localStorage.getItem('pf_playbackrate') || 1.0);
+          player.on('playbackratechange', function(data) {
+            localStorage.setItem('pf_playbackrate', data.playbackRate);
+          });      
         });
         """)
     : []


### PR DESCRIPTION
caveat emptor: couldn't test this locally, but the bits worked when manually run from safari debugger.

see [Slack thread](https://pointfreecommunity.slack.com/archives/C04L56P2VEF/p1699373344457719)

### to test

view an episode, change video playback rate. (gear icon)
quit safari, relaunch, view a different episode, check its rate

expect: its playback rate will be what you last used