### PR TITLE
Persist playback rate

### DIFF
--- a/Sources/Views/EpisodeVideoView.swift
+++ b/Sources/Views/EpisodeVideoView.swift
@@ -66,6 +66,13 @@ public func videoView(
             player.setCurrentTime(time)
             if (play) { player.play() }
           }
+        
+          player.setPlaybackRate( localStorage.getItem('pf_playbackrate') || 1.0
+          );
+          player.on('playbackratechange', function(data) {
+            localStorage.setItem('pf_playbackrate', data.playbackRate);
+          });
+
         });
         """
     ),


### PR DESCRIPTION
see [Slack thread](https://pointfreecommunity.slack.com/archives/C04L56P2VEF/p1699373344457719)

### to test

view an episode, change video playback rate. (gear icon)
quit safari, relaunch, view a different episode, check its rate

expect: its playback rate will be what you last used