### PR TITLE
Fix teammates query.

### DIFF
--- a/Sources/Database/Live.swift
+++ b/Sources/Database/Live.swift
@@ -286,6 +286,8 @@ extension Client {
           FROM "users"
           INNER JOIN "subscriptions" ON "users"."subscription_id" = "subscriptions"."id"
           WHERE "subscriptions"."user_id" = \(bind: ownerId)
+          AND "subscriptions"."stripe_subscription_status" = 'active'
+          ORDER BY "subscriptions"."created_at" DESC
           """
         )
       },


### PR DESCRIPTION
If a team subscription owner has two subscriptions, a past cancelled one and a current active one, then the teammates on the old subscription will show up on the team page of the new one. We will stop showing them on that page to make it clear that they need to be invited to the new subscription to regain access.