### PR TITLE
Fix index of inline style classes.

### DIFF
--- a/Sources/StyleguideV2/HTML/HTMLInlineStyle.swift
+++ b/Sources/StyleguideV2/HTML/HTMLInlineStyle.swift
@@ -109,7 +109,7 @@ private struct ClassNameGenerator: DependencyKey {
           seenStyles.firstIndex(of: style)
           ?? {
             seenStyles.append(style)
-            return seenStyles.count
+            return seenStyles.count - 1
           }()
         #if DEBUG
           return "\(style.property)-\(index)"


### PR DESCRIPTION
My last PR (#925) computed the index of class names incorrectly. After inserting a class into the set it then used the set count for the index, but it should have been 1 less.