### PR TITLE
Fixed a typo 'momths' to 'months'

### DIFF
--- a/Sources/Views/GiftsV2.swift
+++ b/Sources/Views/GiftsV2.swift
@@ -31,7 +31,7 @@ public struct GiftsV2: HTML {
           .attribute("href", siteRouter.path(for: .gifts(.plan(.threeMonths))))
         }
 
-        PricingLane("6 momths", annualPricePerMonth: 108) {
+        PricingLane("6 months", annualPricePerMonth: 108) {
           "One-time payment"
         } features: {
           baseFeatures


### PR DESCRIPTION
The page https://www.pointfree.co/gifts has a typo, which this PR fixes.

