### PR TITLE
Update swiftlang repository link for Package.swift and Package.resolved

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -102,7 +102,7 @@
     {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
       "state" : {
         "revision" : "3bc2f3e25df0cecc5dc269f7ccae65d0f386f06a",
         "version" : "0.4.0"
@@ -183,7 +183,7 @@
     {
       "identity" : "swift-markdown",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown",
+      "location" : "https://github.com/swiftlang/swift-markdown",
       "state" : {
         "revision" : "4aae40bf6fff5286e0e1672329d17824ce16e081",
         "version" : "0.4.0"
@@ -300,7 +300,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ var package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     .package(url: "https://github.com/apple/swift-log", from: "1.5.0"),
-    .package(url: "https://github.com/apple/swift-markdown", from: "0.4.0"),
+    .package(url: "https://github.com/swiftlang/swift-markdown", from: "0.4.0"),
     .package(url: "https://github.com/apple/swift-nio", from: "2.61.0"),
     .package(url: "https://github.com/swift-server/async-http-client", from: "1.19.0"),
     .package(url: "https://github.com/vapor/postgres-kit", from: "2.12.0"),


### PR DESCRIPTION
### Summary:

Update links for repositories moved to the swiftlang org on GitHub

### Modifications:

+ Package.resolved
+ Package.swift

### Result:

Correct the link:
+ https://github.com/apple/swift-cmark => https://github.com/swiftlang/swift-cmark
+ https://github.com/apple/swift-markdown => https://github.com/swiftlang/swift-markdown
+ https://github.com/apple/swift-syntax => https://github.com/swiftlang/swift-syntax