### PR TITLE
Don't fail login if Stripe is having problems.

### DIFF
--- a/Sources/PointFree/Auth.swift
+++ b/Sources/PointFree/Auth.swift
@@ -359,7 +359,9 @@ private func gitHubAuthTokenMiddleware(
   do {
     let gitHubUser = try await gitHub.fetchUser(accessToken)
     let user = try await fetchOrRegisterUser(accessToken: accessToken, gitHubUser: gitHubUser)
-    try await refreshStripeSubscription(for: user)
+    await notifyError("GitHub Auth: Refresh stripe failed") {
+      try await refreshStripeSubscription(for: user)
+    }
     return conn.redirect(to: redirect ?? siteRouter.path(for: .home)) {
       $0.writeSessionCookie { $0.user = .standard(user.id) }
     }
@@ -385,7 +387,7 @@ private func gitHubAuthTokenMiddleware(
   }
 }
 
-private func refreshStripeSubscription(for user: Models.User) async throws {
+func refreshStripeSubscription(for user: Models.User) async throws {
   @Dependency(\.database) var database
   @Dependency(\.stripe) var stripe
 

--- a/Tests/PointFreeTests/AuthTests.swift
+++ b/Tests/PointFreeTests/AuthTests.swift
@@ -2,6 +2,7 @@ import Dependencies
 import Either
 import HttpPipeline
 import InlineSnapshotTesting
+import Models
 import PointFreePrelude
 import PointFreeRouter
 import PointFreeTestSupport
@@ -327,6 +328,39 @@ class AuthTests: TestCase {
     let conn = connection(from: login)
 
     await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
+  }
+
+  @MainActor
+  func testLogin_StripeFailure() async throws {
+    await withDependencies {
+      $0.gitHub.fetchUser = { _ in .mock }
+      $0.stripe.fetchSubscription = { _ in
+        struct Error: Swift.Error {}
+        throw Error()
+      }
+    } operation: {
+      let auth = request(to: .auth(.gitHubCallback(code: "deadbeef", redirect: nil)))
+      let conn = connection(from: auth)
+      XCTExpectFailure {
+        $0.compactDescription.contains("GitHub Auth: Refresh stripe failed")
+      }
+      await assertInlineSnapshot(of: await siteMiddleware(conn), as: .conn) {
+        """
+        GET http://localhost:8080/github-auth?code=deadbeef
+        Cookie: pf_session={}
+
+        302 Found
+        Location: /
+        Referrer-Policy: strict-origin-when-cross-origin
+        Set-Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
+        X-Content-Type-Options: nosniff
+        X-Download-Options: noopen
+        X-Frame-Options: SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies: none
+        X-XSS-Protection: 1; mode=block
+        """
+      }
+    }
   }
 
   @MainActor

--- a/Tests/PointFreeTests/AuthTests.swift
+++ b/Tests/PointFreeTests/AuthTests.swift
@@ -330,38 +330,42 @@ class AuthTests: TestCase {
     await assertSnapshot(matching: await siteMiddleware(conn), as: .conn)
   }
 
-  @MainActor
-  func testLogin_StripeFailure() async throws {
-    await withDependencies {
-      $0.gitHub.fetchUser = { _ in .mock }
-      $0.stripe.fetchSubscription = { _ in
-        struct Error: Swift.Error {}
-        throw Error()
-      }
-    } operation: {
-      let auth = request(to: .auth(.gitHubCallback(code: "deadbeef", redirect: nil)))
-      let conn = connection(from: auth)
-      XCTExpectFailure {
-        $0.compactDescription.contains("GitHub Auth: Refresh stripe failed")
-      }
-      await assertInlineSnapshot(of: await siteMiddleware(conn), as: .conn) {
-        """
-        GET http://localhost:8080/github-auth?code=deadbeef
-        Cookie: pf_session={}
+  #if !os(Linux)
+    @MainActor
+    func testLogin_StripeFailure() async throws {
+      await withIssueReporters([]) {
+        await withDependencies {
+          $0.gitHub.fetchUser = { _ in .mock }
+          $0.stripe.fetchSubscription = { _ in
+            struct Error: Swift.Error {}
+            throw Error()
+          }
+        } operation: {
+          let auth = request(to: .auth(.gitHubCallback(code: "deadbeef", redirect: nil)))
+          let conn = connection(from: auth)
+          XCTExpectFailure {
+            $0.compactDescription.contains("GitHub Auth: Refresh stripe failed")
+          }
+          await assertInlineSnapshot(of: await siteMiddleware(conn), as: .conn) {
+            """
+            GET http://localhost:8080/github-auth?code=deadbeef
+            Cookie: pf_session={}
 
-        302 Found
-        Location: /
-        Referrer-Policy: strict-origin-when-cross-origin
-        Set-Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
-        X-Content-Type-Options: nosniff
-        X-Download-Options: noopen
-        X-Frame-Options: SAMEORIGIN
-        X-Permitted-Cross-Domain-Policies: none
-        X-XSS-Protection: 1; mode=block
-        """
+            302 Found
+            Location: /
+            Referrer-Policy: strict-origin-when-cross-origin
+            Set-Cookie: pf_session={"userId":"00000000-0000-0000-0000-000000000000"}; Expires=Sat, 29 Jan 2028 00:00:00 GMT; Path=/
+            X-Content-Type-Options: nosniff
+            X-Download-Options: noopen
+            X-Frame-Options: SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies: none
+            X-XSS-Protection: 1; mode=block
+            """
+          }
+        }
       }
     }
-  }
+  #endif
 
   @MainActor
   func testLogin_AlreadyLoggedIn() async throws {


### PR DESCRIPTION
Yesterday log in was broken for awhile on Point-Free because the Stripe API was having problems, and we refresh the user's subscription state when they log in. Let's not prevent log in if Stripe is having problems. Also let's refresh the user's subscription state when they visit their account page.