### PR TITLE
Fully re-enable subscribe form after failure

### DIFF
--- a/Sources/PointFree/Subscribe.swift
+++ b/Sources/PointFree/Subscribe.swift
@@ -93,8 +93,12 @@ private func subscribe(
         )
       }
 
-      let ipCountry = conn.request.value(forHTTPHeaderField: "CF-IPCountry")
-        .map(Stripe.Country.init(rawValue:))
+      #if DEBUG
+        let ipCountry = country
+      #else
+        let ipCountry = conn.request.value(forHTTPHeaderField: "CF-IPCountry")
+          .map(Stripe.Country.init(rawValue:))
+        #endif
       guard
         !subscribeData.useRegionalDiscount
           || ipCountry == country

--- a/Sources/Views/SubscriptionConfirmation.swift
+++ b/Sources/Views/SubscriptionConfirmation.swift
@@ -1362,14 +1362,19 @@ private func checkoutJS(
             if (json.error) {
               displayError.innerHTML = json.error || defaultError
               setFormEnabled(true, function() { return true })
+              submitting = false
             } else if (json.requiresAction) {
               const { paymentIntent, error } = await stripe.confirmCardPayment(json.clientSecret)
               if (error) {
                 displayError.innerHTML = error.message || defaultError
                 setFormEnabled(true, function() { return true })
+                submitting = false
               } else if (paymentIntent.status === "succeeded") {
                 form.\(SubscribeData.CodingKeys.subscriptionID.rawValue).value = json.subscriptionID
                 form.submit()
+              } else {
+                setFormEnabled(true, function() { return true })
+                submitting = false
               }
             } else {
               window.location.href = '/account'


### PR DESCRIPTION
We have a `submitting` guard that doesn't always get flipped back to `false`, so let's fix that.