### PR TITLE
Fix floating point bug in Apple Pay.

### DIFF
--- a/Sources/Views/SubscriptionConfirmation.swift
+++ b/Sources/Views/SubscriptionConfirmation.swift
@@ -1034,21 +1034,22 @@ private func total(
               if (!\#(supportsBillingToggle)) {
                 monthly = \#(defaultIsMonthly)
               }
-              const monthlySeatPrice = \#(discountedMonthlySeatPriceInCents) * 0.01 * regionalDiscount
-              const yearlySeatPrice = \#(discountedYearlySeatPriceInCents) * 0.01 * regionalDiscount
-              const seatPrice = monthly ? monthlySeatPrice : yearlySeatPrice
-              const subtotal = seats * seatPrice
-              const total = monthly
-                ? subtotal
-                : Math.max(0, subtotal - \#(referralDiscount) * regionalDiscount)
-              var previewUnitPrice = seatPrice
+              const monthlySeatPriceInCents = Math.round(\#(discountedMonthlySeatPriceInCents) * regionalDiscount)
+              const yearlySeatPriceInCents = Math.round(\#(discountedYearlySeatPriceInCents) * regionalDiscount)
+              const seatPriceInCents = monthly ? monthlySeatPriceInCents : yearlySeatPriceInCents
+              const subtotalInCents = seats * seatPriceInCents
+              const totalInCents = monthly
+                ? subtotalInCents
+                : Math.max(0, subtotalInCents - Math.round(\#(referralDiscount * 100) * regionalDiscount))
+              const total = totalInCents / 100
+              var previewUnitPrice = seatPriceInCents / 100
               var previewUnitText = "\#(defaultPreviewUnitText)"
               var monthMultiplierSuffix = ""
               if (\#(supportsBillingToggle)) {
                 previewUnitText = monthly ? "per month" : "per year"
               }
               if (\#(isProTeamAnnual)) {
-                previewUnitPrice = seatPrice / 12
+                previewUnitPrice = seatPriceInCents / 1200
                 previewUnitText = "per member per month"
                 monthMultiplierSuffix = " times <strong>12 months</strong>"
               }
@@ -1065,7 +1066,7 @@ private func total(
                 window.paymentRequest.update({
                   total: {
                     label: monthly ? "Monthly membership" : "Yearly membership",
-                    amount: total * 100
+                    amount: totalInCents
                   }
                 })
               }


### PR DESCRIPTION
Right now we perform money calculations with floats and then multiply by 100 when updating the "amount" field in the payment request. With our previous pricing scheme that was OK, but with the new pricing we are getting a non-expressible float (e.g. "151.20000000000002"), and that seems to be rejected by Apple Pay and so defaults to "$1". I've updated the javascript to just now deal with cents the whole time and avoid floats for the most part.